### PR TITLE
Rename Auto funcs to NoAuto

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -26,9 +26,9 @@ type RelationalStoreDefinition struct {
 	Parent           *StorageGroupDefinition
 	Type             RelationalStorageType
 	RelationalModels map[string]*RelationalModelDefinition
-	AutoIDGenerate   bool
-	AutoTimestamps   bool
-	AutoSoftDelete   bool
+	NoAutoIDFields   bool
+	NoAutoTimestamps bool
+	NoAutoSoftDelete bool
 }
 
 // RelationalModelDefinition implements the storage of a domain model into a

--- a/dsl/relationalmodel.go
+++ b/dsl/relationalmodel.go
@@ -26,9 +26,9 @@ func Model(name string, dsl func()) {
 		if s.RelationalModels == nil {
 			s.RelationalModels = make(map[string]*gorma.RelationalModelDefinition)
 		}
-		models, ok := s.RelationalModels[name]
+		model, ok := s.RelationalModels[name]
 		if !ok {
-			models = &gorma.RelationalModelDefinition{
+			model = &gorma.RelationalModelDefinition{
 				Name:             name,
 				DefinitionDSL:    dsl,
 				Parent:           s,
@@ -39,48 +39,48 @@ func Model(name string, dsl func()) {
 				ManyToMany:       make(map[string]*gorma.ManyToManyDefinition),
 			}
 		} else {
-			models.DefinitionDSL = dsl
+			model.DefinitionDSL = dsl
 		}
-		///models.PopulateFromModeledType() -- need to do this later
-		s.RelationalModels[name] = models
-		if s.AutoIDGenerate {
+		///model.PopulateFromModeledType() -- need to do this later
+		s.RelationalModels[name] = model
+		if !s.NoAutoIDFields {
 			field := &gorma.RelationalFieldDefinition{
 				Name:              SanitizeFieldName("ID"),
-				Parent:            models,
+				Parent:            model,
 				Datatype:          gorma.PKInteger,
 				PrimaryKey:        true,
 				DatabaseFieldName: SanitizeDBFieldName("ID"),
 			}
-			models.RelationalFields[field.Name] = field
+			model.RelationalFields[field.Name] = field
 		}
-		if s.AutoTimestamps {
+		if !s.NoAutoTimestamps {
 			// add createdat
 			field := &gorma.RelationalFieldDefinition{
 				Name:              SanitizeFieldName("CreatedAt"),
-				Parent:            models,
+				Parent:            model,
 				Datatype:          gorma.Timestamp,
 				DatabaseFieldName: SanitizeDBFieldName("CreatedAt"),
 			}
-			models.RelationalFields[field.Name] = field
+			model.RelationalFields[field.Name] = field
 			// add updatedat
 			field = &gorma.RelationalFieldDefinition{
 				Name:              SanitizeFieldName("UpdatedAt"),
-				Parent:            models,
+				Parent:            model,
 				Datatype:          gorma.Timestamp,
 				DatabaseFieldName: SanitizeDBFieldName("UpdatedAt"),
 			}
-			models.RelationalFields[field.Name] = field
+			model.RelationalFields[field.Name] = field
 		}
-		if s.AutoSoftDelete {
+		if !s.NoAutoSoftDelete {
 			// Add softdelete
 			field := &gorma.RelationalFieldDefinition{
 				Name:              SanitizeFieldName("DeletedAt"),
-				Parent:            models,
+				Parent:            model,
 				Nullable:          true,
 				Datatype:          gorma.NullableTimestamp,
 				DatabaseFieldName: SanitizeDBFieldName("DeletedAt"),
 			}
-			models.RelationalFields[field.Name] = field
+			model.RelationalFields[field.Name] = field
 		}
 	}
 }

--- a/dsl/relationalmodel_test.go
+++ b/dsl/relationalmodel_test.go
@@ -389,9 +389,6 @@ var _ = Describe("RelationalModel with auto fields enabled and auto fields set i
 	JustBeforeEach(func() {
 		gdsl.StorageGroup(sgname, func() {
 			gdsl.Store(storename, gorma.MySQL, func() {
-				gdsl.AutomaticIDFields(true)
-				gdsl.AutomaticTimestamps(true)
-				gdsl.AutomaticSoftDelete(true)
 				gdsl.Model(name, dsl)
 				gdsl.Model("Child", func() {
 					gdsl.BuiltFrom(ChildPayload)
@@ -485,9 +482,6 @@ var _ = Describe("RelationalModel with auto fields explicitly enabled", func() {
 	JustBeforeEach(func() {
 		gdsl.StorageGroup(sgname, func() {
 			gdsl.Store(storename, gorma.MySQL, func() {
-				gdsl.AutomaticIDFields(true)
-				gdsl.AutomaticTimestamps(true)
-				gdsl.AutomaticSoftDelete(true)
 				gdsl.Model(name, dsl)
 				gdsl.Model("Child", func() {
 					gdsl.BuiltFrom(ChildPayload)
@@ -575,9 +569,9 @@ var _ = Describe("RelationalModel with auto fields disabled", func() {
 	JustBeforeEach(func() {
 		gdsl.StorageGroup(sgname, func() {
 			gdsl.Store(storename, gorma.MySQL, func() {
-				gdsl.AutomaticIDFields(false)
-				gdsl.AutomaticTimestamps(false)
-				gdsl.AutomaticSoftDelete(false)
+				gdsl.NoAutomaticIDFields()
+				gdsl.NoAutomaticTimestamps()
+				gdsl.NoAutomaticSoftDelete()
 				gdsl.Model(name, dsl)
 				gdsl.Model("Child", func() {
 					gdsl.BuiltFrom(ChildPayload)

--- a/dsl/relationalstore.go
+++ b/dsl/relationalstore.go
@@ -23,9 +23,6 @@ func Store(name string, storeType gorma.RelationalStorageType, dsl func()) {
 				Parent:           s,
 				Type:             storeType,
 				RelationalModels: make(map[string]*gorma.RelationalModelDefinition),
-				AutoTimestamps:   true,
-				AutoIDGenerate:   true,
-				AutoSoftDelete:   true,
 			}
 		}
 		s.RelationalStores[name] = store
@@ -33,33 +30,30 @@ func Store(name string, storeType gorma.RelationalStorageType, dsl func()) {
 
 }
 
-// AutomaticIDFields applies to a `Store` type.  It allows you
+// NoAutomaticIDFields applies to a `Store` type.  It allows you
 // to turn off the default behavior that will automatically create
-// an ID/int Primary Key for each model.  If set to false,
-// no ID field will be generated.
-func AutomaticIDFields(auto bool) {
-	if r, ok := relationalStoreDefinition(false); ok {
-		r.AutoIDGenerate = auto
+// an ID/int Primary Key for each model.
+func NoAutomaticIDFields() {
+	if s, ok := relationalStoreDefinition(false); ok {
+		s.NoAutoIDFields = true
 	}
 }
 
-// AutomaticTimestamps applies to a `Store` type.  It allows you
+// NoAutomaticTimestamps applies to a `Store` type.  It allows you
 // to turn off the default behavior that will automatically create
-// an `CreatedAt` and `UpdatedAt` fields for each model.  If set to false,
-// these fields won't be created.
-func AutomaticTimestamps(auto bool) {
-	if r, ok := relationalStoreDefinition(false); ok {
-		r.AutoTimestamps = auto
+// an `CreatedAt` and `UpdatedAt` fields for each model.
+func NoAutomaticTimestamps() {
+	if s, ok := relationalStoreDefinition(false); ok {
+		s.NoAutoTimestamps = true
 	}
 }
 
-// AutomaticSoftDelete applies to a `Store` type.  It allows
+// NoAutomaticSoftDelete applies to a `Store` type.  It allows
 // you to turn off the default behavior that will automatically
 // create a `DeletedAt` field (*time.Time) that acts as a
-// soft-delete filter for your models.  If set to false,
-// this field won't be created.
-func AutomaticSoftDelete(auto bool) {
-	if r, ok := relationalStoreDefinition(false); ok {
-		r.AutoSoftDelete = auto
+// soft-delete filter for your models.
+func NoAutomaticSoftDelete() {
+	if s, ok := relationalStoreDefinition(false); ok {
+		s.NoAutoSoftDelete = true
 	}
 }

--- a/dsl/relationalstore_test.go
+++ b/dsl/relationalstore_test.go
@@ -93,84 +93,78 @@ var _ = Describe("RelationalStore", func() {
 			})
 			It("auto id generation defaults to true", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoIDGenerate).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoIDFields).Should(Equal(false))
 			})
 			It("auto timestamps defaults to true", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoTimestamps).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoTimestamps).Should(Equal(false))
 			})
 			It("auto soft delete defaults to true", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoSoftDelete).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoSoftDelete).Should(Equal(false))
 			})
 		})
-		Context("with a AutoID off", func() {
-			const auto = false
-
+		Context("with NoAutomaticIDFields", func() {
 			BeforeEach(func() {
 				name = "mysql"
 				dsl = func() {
-					gdsl.AutomaticIDFields(auto)
+					gdsl.NoAutomaticIDFields()
 				}
 			})
 
 			It("auto id generation should be off", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoIDGenerate).Should(Equal(false))
+				Ω(sg.RelationalStores[name].NoAutoIDFields).Should(Equal(true))
 			})
 			It("auto timestamps defaults to true", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoTimestamps).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoTimestamps).Should(Equal(false))
 			})
 			It("auto soft delete defaults to true", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoSoftDelete).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoSoftDelete).Should(Equal(false))
 			})
 		})
-		Context("with a AutoTimestamps off", func() {
-			const auto = false
-
+		Context("with NoAutomaticTimestamps", func() {
 			BeforeEach(func() {
 				name = "mysql"
 				dsl = func() {
-					gdsl.AutomaticTimestamps(auto)
+					gdsl.NoAutomaticTimestamps()
 				}
 			})
 
 			It("auto id generation should be on", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoIDGenerate).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoIDFields).Should(Equal(false))
 			})
 			It("auto timestamps should be off", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoTimestamps).Should(Equal(auto))
+				Ω(sg.RelationalStores[name].NoAutoTimestamps).Should(Equal(true))
 			})
 			It("auto soft delete should be on", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoSoftDelete).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoSoftDelete).Should(Equal(false))
 			})
 		})
-		Context("with a AutoSoftDelete off", func() {
-			const auto = false
-
+		Context("with NoAutomaticSoftDelete", func() {
 			BeforeEach(func() {
 				name = "mysql"
 				dsl = func() {
-					gdsl.AutomaticSoftDelete(auto)
+					gdsl.NoAutomaticSoftDelete()
 				}
 			})
 
 			It("auto id generation should be on", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoIDGenerate).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoIDFields).Should(Equal(false))
 			})
 			It("auto timestamps should be on", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoTimestamps).Should(Equal(true))
+				Ω(sg.RelationalStores[name].NoAutoTimestamps).Should(Equal(false))
 			})
 			It("auto soft delete should be off", func() {
 				sg := gorma.GormaDesign
-				Ω(sg.RelationalStores[name].AutoSoftDelete).Should(Equal(auto))
+				Ω(sg.RelationalStores[name].NoAutoSoftDelete).Should(Equal(true))
 			})
 		})
 


### PR DESCRIPTION
I like this design better.  Using negative DSL function names for bools lets us
take advantage of Go default values so that we don't have to initialize
anything.

Also fixed a s/models/model/ variable name issue in Model().