### PR TITLE
Cleanup template

### DIFF
--- a/writers.go
+++ b/writers.go
@@ -129,51 +129,50 @@ func arrayAttribute(a *design.AttributeDefinition) *design.AttributeDefinition {
 const (
 	// userTypeT generates the code for a user type.
 	// template input: UserTypeTemplateData
-	userTypeT = `// {{if .UserType.Description}}{{.UserType.Description}} {{end}}
-{{.UserType.StructDefinition}}
-{{ if ne .UserType.Alias "" }}
+	userTypeT = `{{$ut := .UserType}}{{$ap := .AppPkg}}// {{if $ut.Description}}{{$ut.Description}} {{end}}
+{{$ut.StructDefinition}}
+{{ if ne $ut.Alias "" }}
 // TableName overrides the table name settings in Gorm to force a specific table name
 // in the database.
-func (m {{.UserType.Name}}) TableName() string {
-	return "{{ .UserType.Alias}}"
+func (m {{$ut.Name}}) TableName() string {
+	return "{{ $ut.Alias}}"
 }{{end}}
-// {{.UserType.Name}}DB is the implementation of the storage interface for
-// {{.UserType.Name}}.
-type {{.UserType.Name}}DB struct {
+// {{$ut.Name}}DB is the implementation of the storage interface for
+// {{$ut.Name}}.
+type {{$ut.Name}}DB struct {
 	Db gorm.DB
-	{{ if .UserType.Cached }}cache *cache.Cache{{end}}
+	{{ if $ut.Cached }}cache *cache.Cache{{end}}
 }
-// New{{.UserType.Name}}DB creates a new storage type.
-func New{{.UserType.Name}}DB(db gorm.DB) *{{.UserType.Name}}DB {
-	{{ if .UserType.Cached }}return &{{.UserType.Name}}DB{
+// New{{$ut.Name}}DB creates a new storage type.
+func New{{$ut.Name}}DB(db gorm.DB) *{{$ut.Name}}DB {
+	{{ if $ut.Cached }}return &{{$ut.Name}}DB{
 		Db: db,
 		cache: cache.New(5*time.Minute, 30*time.Second),
 	}
-	{{ else  }}return &{{.UserType.Name}}DB{Db: db}{{ end  }}
+	{{ else  }}return &{{$ut.Name}}DB{Db: db}{{ end  }}
 }
 // DB returns the underlying database.
-func (m *{{.UserType.Name}}DB) DB() interface{} {
+func (m *{{$ut.Name}}DB) DB() interface{} {
 	return &m.Db
 }
-{{ if .UserType.Roler }}
+{{ if $ut.Roler }}
 // GetRole returns the value of the role field and satisfies the Roler interface.
-func (m {{.UserType.Name}}) GetRole() string {
-	return {{$f := .UserType.Fields.role}}{{if $f.Nullable}}*{{end}}m.Role
+func (m {{$ut.Name}}) GetRole() string {
+	return {{$f := $ut.Fields.role}}{{if $f.Nullable}}*{{end}}m.Role
 }
 {{end}}
 
-
-// {{.UserType.Name}}Storage represents the storage interface.
-type {{.UserType.Name}}Storage interface {
+// {{$ut.Name}}Storage represents the storage interface.
+type {{$ut.Name}}Storage interface {
 	DB() interface{}
-	List(ctx context.Context{{ if .UserType.DynamicTableName}}, tableName string{{ end }}) []{{.UserType.Name}}
-	One(ctx context.Context{{ if .UserType.DynamicTableName }}, tableName string{{ end }}, {{.UserType.PKAttributes}}) ({{.UserType.Name}}, error)
-	Add(ctx context.Context{{ if .UserType.DynamicTableName }}, tableName string{{ end }}, {{.UserType.LowerName}} {{.UserType.Name}}) ({{.UserType.Name}}, error)
-	Update(ctx context.Context{{ if .UserType.DynamicTableName }}, tableName string{{ end }}, {{.UserType.LowerName}} {{.UserType.Name}}) (error)
-	Delete(ctx context.Context{{ if .UserType.DynamicTableName }}, tableName string{{ end }}, {{ .UserType.PKAttributes}}) (error) 	{{$typename:= .UserType.Name}}{{$dtn:=.UserType.DynamicTableName}}{{ range $idx, $bt := .UserType.BelongsTo}}
-	ListBy{{$bt.Name}}(ctx context.Context{{ if $dtn}}, tableName string{{ end }},{{$bt.LowerName}}_id int) []{{$typename}}
-	OneBy{{$bt.Name}}(ctx context.Context{{ if $dtn}}, tableName string{{ end }}, {{$bt.LowerName}}_id, id int) ({{$typename}}, error){{end}}
-	{{range $i, $m2m := .UserType.ManyToMany}}
+	List(ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}) []{{$ut.Name}}
+	One(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}}) ({{$ut.Name}}, error)
+	Add(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}} {{$ut.Name}}) ({{$ut.Name}}, error)
+	Update(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}} {{$ut.Name}}) (error)
+	Delete(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{ $ut.PKAttributes}}) (error) 	{{$dtn:=$ut.DynamicTableName}}{{ range $idx, $bt := $ut.BelongsTo}}
+	ListBy{{$bt.Name}}(ctx context.Context{{ if $dtn}}, tableName string{{ end }},{{$bt.LowerName}}_id int) []{{$ut.Name}}
+	OneBy{{$bt.Name}}(ctx context.Context{{ if $dtn}}, tableName string{{ end }}, {{$bt.LowerName}}_id, id int) ({{$ut.Name}}, error){{end}}
+	{{range $i, $m2m := $ut.ManyToMany}}
 	List{{$m2m.RightNamePlural}}(context.Context, int) []{{$m2m.RightName}}
 	Add{{$m2m.RightNamePlural}}(context.Context, int, int) (error)
 	Delete{{$m2m.RightNamePlural}}(context.Context, int, int) error
@@ -183,40 +182,40 @@ type {{.UserType.Name}}Storage interface {
 // CRUD Functions
 
 // List returns an array of records.
-func (m *{{$typename}}DB) List(ctx context.Context{{ if .UserType.DynamicTableName}}, tableName string{{ end }}) []{{$typename}} {
-	var objs []{{$typename}}
-	m.Db{{ if .UserType.DynamicTableName }}.Table(tableName){{ end }}.Find(&objs)
+func (m *{{$ut.Name}}DB) List(ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}) []{{$ut.Name}} {
+	var objs []{{$ut.Name}}
+	m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Find(&objs)
 	return objs
 }
 
 // One returns a single record by ID.
-func (m *{{$typename}}DB) One(ctx context.Context{{ if .UserType.DynamicTableName }}, tableName string{{ end }}, {{.UserType.PKAttributes}}) ({{$typename}}, error) {
-	{{ if .UserType.Cached }}//first attempt to retrieve from cache
+func (m *{{$ut.Name}}DB) One(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}}) ({{$ut.Name}}, error) {
+	{{ if $ut.Cached }}//first attempt to retrieve from cache
 	o,found := m.cache.Get(strconv.Itoa(id))
 	if found {
-		return o.({{$typename}}), nil
+		return o.({{$ut.Name}}), nil
 	}
 	// fallback to database if not found{{ end }}
-	var obj {{$typename}}{{ $l := len $.UserType.PrimaryKeys }}
+	var obj {{$ut.Name}}{{ $l := len $ut.PrimaryKeys }}
 	{{ if eq $l 1 }}
-	err := m.Db{{ if .UserType.DynamicTableName }}.Table(tableName){{ end }}.Find(&obj, id).Error{{ else  }}err := m.Db{{ if .UserType.DynamicTableName }}.Table(tableName){{ end }}.Find(&obj).Where("{{.UserType.PKWhere}}", {{.UserType.PKWhereFields }}).Error{{ end }}
-	{{ if .UserType.Cached }} go m.cache.Set(strconv.Itoa(id), obj, cache.DefaultExpiration) {{ end }}
+	err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Find(&obj, id).Error{{ else  }}err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Find(&obj).Where("{{$ut.PKWhere}}", {{$ut.PKWhereFields }}).Error{{ end }}
+	{{ if $ut.Cached }} go m.cache.Set(strconv.Itoa(id), obj, cache.DefaultExpiration) {{ end }}
 	return obj, err
 }
 // Add creates a new record.
-func (m *{{$typename}}DB) Add(ctx context.Context{{ if .UserType.DynamicTableName }}, tableName string{{ end }}, model {{$typename}}) ({{$typename}}, error) {
-	err := m.Db{{ if .UserType.DynamicTableName }}.Table(tableName){{ end }}.Create(&model).Error{{ if .UserType.Cached }}
+func (m *{{$ut.Name}}DB) Add(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, model {{$ut.Name}}) ({{$ut.Name}}, error) {
+	err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Create(&model).Error{{ if $ut.Cached }}
 	go m.cache.Set(strconv.Itoa(model.ID), model, cache.DefaultExpiration) {{ end }}
 	return model, err
 }
 // Update modifies a single record.
-func (m *{{$typename}}DB) Update(ctx context.Context{{ if .UserType.DynamicTableName }}, tableName string{{ end }}, model {{$typename}}) error {
-	obj, err := m.One(ctx{{ if .UserType.DynamicTableName }}, tableName{{ end }}, {{.UserType.PKUpdateFields "model"}})
+func (m *{{$ut.Name}}DB) Update(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, model {{$ut.Name}}) error {
+	obj, err := m.One(ctx{{ if $ut.DynamicTableName }}, tableName{{ end }}, {{$ut.PKUpdateFields "model"}})
 	if err != nil {
 		return  err
 	}
-	err = m.Db{{ if .UserType.DynamicTableName }}.Table(tableName){{ end }}.Model(&obj).Updates(model).Error
-	{{ if .UserType.Cached }}go func(){
+	err = m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Model(&obj).Updates(model).Error
+	{{ if $ut.Cached }}go func(){
 	obj, err := m.One(ctx, model.ID)
 	if err == nil {
 		m.cache.Set(strconv.Itoa(model.ID), obj, cache.DefaultExpiration)
@@ -226,23 +225,23 @@ func (m *{{$typename}}DB) Update(ctx context.Context{{ if .UserType.DynamicTable
 	return err
 }
 // Delete removes a single record.
-func (m *{{$typename}}DB) Delete(ctx context.Context{{ if .UserType.DynamicTableName }}, tableName string{{ end }}, {{.UserType.PKAttributes}})  error {
-	var obj {{$typename}}{{ $l := len .UserType.PrimaryKeys }}
+func (m *{{$ut.Name}}DB) Delete(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}})  error {
+	var obj {{$ut.Name}}{{ $l := len $ut.PrimaryKeys }}
 	{{ if eq $l 1 }}
-	err := m.Db{{ if .UserType.DynamicTableName }}.Table(tableName){{ end }}.Delete(&obj, id).Error
-	{{ else  }}err := m.Db{{ if .UserType.DynamicTableName }}.Table(tableName){{ end }}.Delete(&obj).Where("{{.UserType.PKWhere}}", {{.UserType.PKWhereFields}}).Error
+	err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Delete(&obj, id).Error
+	{{ else  }}err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Delete(&obj).Where("{{$ut.PKWhere}}", {{$ut.PKWhereFields}}).Error
 	{{ end }}
 	if err != nil {
 		return  err
 	}
-	{{ if .UserType.Cached }} go m.cache.Delete(strconv.Itoa(id)) {{ end }}
+	{{ if $ut.Cached }} go m.cache.Delete(strconv.Itoa(id)) {{ end }}
 	return  nil
 }
-{{$ut := .UserType}}{{$typename := .UserType.Name}}{{ range $idx, $bt := .UserType.BelongsTo}}
+{{ range $idx, $bt := $ut.BelongsTo}}
 // Belongs To Relationships
 
-// {{$typename}}FilterBy{{$bt.Name}} is a gorm filter for a Belongs To relationship.
-func {{$typename}}FilterBy{{$bt.Name}}(parentid int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
+// {{$ut.Name}}FilterBy{{$bt.Name}} is a gorm filter for a Belongs To relationship.
+func {{$ut.Name}}FilterBy{{$bt.Name}}(parentid int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
 	if parentid > 0 {
 		return func(db *gorm.DB) *gorm.DB {
 			return db.Where("{{$bt.LowerName}}_id = ?", parentid)
@@ -254,32 +253,32 @@ func {{$typename}}FilterBy{{$bt.Name}}(parentid int, originaldb *gorm.DB) func(d
 	}
 }
 // ListBy{{$bt.Name}} returns an array of associated {{$bt.Name}} models.
-func (m *{{$typename}}DB) ListBy{{$bt.Name}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, parentid int) []{{$typename}} {
-	var objs []{{$typename}}
-	m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Scopes({{$typename}}FilterBy{{$bt.Name}}(parentid, &m.Db)).Find(&objs)
+func (m *{{$ut.Name}}DB) ListBy{{$bt.Name}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, parentid int) []{{$ut.Name}} {
+	var objs []{{$ut.Name}}
+	m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Scopes({{$ut.Name}}FilterBy{{$bt.Name}}(parentid, &m.Db)).Find(&objs)
 	return objs
 }
 // OneBy{{$bt.Name}} returns a single associated {{$bt.Name}} model.
-func (m *{{$typename}}DB) OneBy{{$bt.Name}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, parentid, {{ $ut.PKAttributes}}) ({{$typename}}, error) {
+func (m *{{$ut.Name}}DB) OneBy{{$bt.Name}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, parentid, {{ $ut.PKAttributes}}) ({{$ut.Name}}, error) {
 	{{ if $ut.Cached }}//first attempt to retrieve from cache
 	o,found := m.cache.Get(strconv.Itoa(id))
 	if found {
-		return o.({{$typename}}), nil
+		return o.({{$ut.Name}}), nil
 	}
 	// fallback to database if not found{{ end }}
-	var obj {{$typename}}
-	err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Scopes({{$typename}}FilterBy{{$bt.Name}}(parentid, &m.Db)).Find(&obj, id).Error
+	var obj {{$ut.Name}}
+	err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Scopes({{$ut.Name}}FilterBy{{$bt.Name}}(parentid, &m.Db)).Find(&obj, id).Error
 	{{ if $ut.Cached }} go m.cache.Set(strconv.Itoa(id), obj, cache.DefaultExpiration) {{ end }}
 	return obj, err
 }
 {{end}}
 
-{{$ut := .UserType }}{{$typeName := .UserType.Name}}{{ range $idx, $bt := .UserType.ManyToMany}}
+{{ range $idx, $bt := $ut.ManyToMany}}
 // Many To Many Relationships
 
 // Delete{{goify $bt.RightName true}} removes a {{$bt.RightName}}/{{$bt.LeftName}} entry from the join table.
-func (m *{{$typeName}}DB) Delete{{goify $bt.RightName true}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}}ID,  {{$bt.LowerRightName}}ID int)  error {
-	var obj {{$typeName}}
+func (m *{{$ut.Name}}DB) Delete{{goify $bt.RightName true}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}}ID,  {{$bt.LowerRightName}}ID int)  error {
+	var obj {{$ut.Name}}
 	obj.ID = {{$ut.LowerName}}ID
 	var assoc {{$bt.RightName}}
 	var err error
@@ -294,8 +293,8 @@ func (m *{{$typeName}}DB) Delete{{goify $bt.RightName true}}(ctx context.Context
 	return  nil
 }
 // Add{{goify $bt.RightName true}} creates a new {{$bt.RightName}}/{{$bt.LeftName}} entry in the join table.
-func (m *{{$typeName}}DB) Add{{goify $bt.RightName true}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}}ID, {{$bt.LowerRightName}}ID int) error {
-	var {{$ut.LowerName}} {{$typeName}}
+func (m *{{$ut.Name}}DB) Add{{goify $bt.RightName true}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}}ID, {{$bt.LowerRightName}}ID int) error {
+	var {{$ut.LowerName}} {{$ut.Name}}
 	{{$ut.LowerName}}.ID = {{$ut.LowerName}}ID
 	var assoc {{$bt.RightName}}
 	assoc.ID = {{$bt.LowerRightName}}ID
@@ -306,18 +305,18 @@ func (m *{{$typeName}}DB) Add{{goify $bt.RightName true}}(ctx context.Context{{ 
 	return  nil
 }
 // List{{goify $bt.RightName true}} returns a list of the {{$bt.RightName}} models related to this {{$bt.LeftName}}.
-func (m *{{$typeName}}DB) List{{goify $bt.RightName true}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}}ID int)  []{{$bt.RightName}} {
+func (m *{{$ut.Name}}DB) List{{goify $bt.RightName true}}(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}}ID int)  []{{$bt.RightName}} {
 	var list []{{$bt.RightName}}
-	var obj {{$typeName}}
+	var obj {{$ut.Name}}
 	obj.ID = {{$ut.LowerName}}ID
 	m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Model(&obj).Association("{{$bt.RightNamePlural}}").Find(&list)
 	return  list
 }
 {{end}}
-{{ range $idx, $bt := .UserType.BelongsTo}}
-// Filter{{$typename}}By{{$bt.Name}} iterates a list and returns only those with the foreign key provided.
-func Filter{{$typename}}By{{$bt.Name}}(parent *int, list []{{$typename}}) []{{$typename}} {
-	var filtered []{{$typename}}
+{{ range $idx, $bt := $ut.BelongsTo}}
+// Filter{{$ut.Name}}By{{$bt.Name}} iterates a list and returns only those with the foreign key provided.
+func Filter{{$ut.Name}}By{{$bt.Name}}(parent *int, list []{{$ut.Name}}) []{{$ut.Name}} {
+	var filtered []{{$ut.Name}}
 	for _,o := range list {
 		if o.{{$bt.Name}}ID == int(*parent) {
 			filtered = append(filtered,o)
@@ -327,36 +326,36 @@ func Filter{{$typename}}By{{$bt.Name}}(parent *int, list []{{$typename}}) []{{$t
 }
 {{end}}
 
-{{$ap := .AppPkg}}{{ if gt (len .UserType.RenderTo) 0 }}{{$ut := .UserType}}// Useful conversion functions
+{{ if gt (len $ut.RenderTo) 0 }}// Useful conversion functions
 {{range  $tcd := $ut.RenderTo }}{{if $tcd.SupportsNoVersion}}{{ $tcdTypeName := goify $tcd.TypeName true }}
-// To{{$tcdTypeName}} converts a model {{$typeName}} to an app {{$tcdTypeName}}.
-func (m *{{$typeName}}) To{{$tcdTypeName}}() {{$ap}}.{{$tcdTypeName}} {
+// To{{$tcdTypeName}} converts a model {{$ut.Name}} to an app {{$tcdTypeName}}.
+func (m *{{$ut.Name}}) To{{$tcdTypeName}}() {{$ap}}.{{$tcdTypeName}} {
 	payload := {{$ap}}.{{$tcdTypeName}}{}
 	{{ famt $ut $tcd "m" "payload"}}
 	return payload
 }
 {{end}}{{end}}{{end}}
 
-{{ if gt (len .UserType.RenderTo) 0 }}{{$ut := .UserType}}{{range  $tcd := $ut.RenderTo }}{{ range $version := $tcd.APIVersions }}{{ $tcdTypeName := goify $tcd.TypeName true }}
+{{ if gt (len $ut.RenderTo) 0 }}{{range  $tcd := $ut.RenderTo }}{{ range $version := $tcd.APIVersions }}{{ $tcdTypeName := goify $tcd.TypeName true }}
 // To{{if eq $version ""}}{{title $ap}}{{else}}{{title $version}}{{end}}{{$tcdTypeName}} converts to goa types.
-func (m *{{$typeName}}) To{{if eq $version ""}}{{title $ap}}{{else}}{{title $version}}{{end}}{{$tcdTypeName}}() {{if eq $version ""}}{{$ap}}{{else}}{{$version}}{{end}}.{{$tcdTypeName}} {
+func (m *{{$ut.Name}}) To{{if eq $version ""}}{{title $ap}}{{else}}{{title $version}}{{end}}{{$tcdTypeName}}() {{if eq $version ""}}{{$ap}}{{else}}{{$version}}{{end}}.{{$tcdTypeName}} {
 	payload := {{if eq $version ""}}{{$ap}}{{else}}{{$version}}{{end}}.{{$tcdTypeName}}{}
 	{{ famt $ut $tcd "m" "payload"}}
 	return payload
 }
 {{end}}{{end}}{{end}}
 
-{{$ap:= .AppPkg}}{{$ut := .UserType}}{{ range $tcd := $ut.BuiltFrom}}{{ range $version := $tcd.APIVersions }} // v{{$version}}
-// Convert from	{{if eq $version ""}}default version{{else}}Version {{$version}}{{end}} {{$tcd.TypeName}} to {{$typeName}}.
-func {{$typeName}}From{{$version}}{{$tcd.Name}}(t {{if ne $version ""}}{{$version}}.{{else}}{{$ap}}.{{end}}{{$tcd.Name}}) {{$typeName}} {
+{{ range $tcd := $ut.BuiltFrom}}{{ range $version := $tcd.APIVersions }} // v{{$version}}
+// Convert from	{{if eq $version ""}}default version{{else}}Version {{$version}}{{end}} {{$tcd.TypeName}} to {{$ut.Name}}.
+func {{$ut.Name}}From{{$version}}{{$tcd.Name}}(t {{if ne $version ""}}{{$version}}.{{else}}{{$ap}}.{{end}}{{$tcd.Name}}) {{$ut.Name}} {
 	{{$ut.LowerName}} := {{$ut.Name}}{}
 	{{ fatm $ut $tcd.Type "m" $ut.LowerName}}
 	return {{$ut.LowerName}}
 }
 {{end}}{{end}}
-{{$ap:= .AppPkg}}{{$ut := .UserType}}{{ range $tcd := $ut.BuiltFrom}}
-// Convert from	default version {{$tcd.TypeName}} to {{$typeName}}.
-func {{$typeName}}From{{$tcd.TypeName}}(t {{$ap}}.{{$tcd.TypeName}}) {{$typeName}} {
+{{ range $tcd := $ut.BuiltFrom}}
+// Convert from	default version {{$tcd.TypeName}} to {{$ut.Name}}.
+func {{$ut.Name}}From{{$tcd.TypeName}}(t {{$ap}}.{{$tcd.TypeName}}) {{$ut.Name}} {
 	{{$ut.LowerName}} := {{$ut.Name}}{}
 	{{ fatm $ut $tcd "t" $ut.LowerName}}
 	return {{$ut.LowerName}}


### PR DESCRIPTION
- Standardize on using `$ut` instead of `.UserType`.
- Remove `$typename` if favor of `$ut.Name`.
- Move global helper vars to the top of the template.