### PR TITLE
Refactor field alias and fix goify issue

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -128,13 +128,12 @@ type RelationalFieldDefinition struct {
 	FieldName         string
 	Datatype          FieldType
 	SQLTag            string
-	DatabaseFieldName string
+	DatabaseFieldName string // gorm:column
 	Description       string
 	Nullable          bool
 	PrimaryKey        bool
 	Timestamp         bool
-	Size              int    // string field size
-	Alias             string // gorm:column
+	Size              int // string field size
 	BelongsTo         string
 	HasOne            string
 	HasMany           string

--- a/dsl/relationalmodel.go
+++ b/dsl/relationalmodel.go
@@ -338,7 +338,7 @@ func Alias(d string) {
 	if r, ok := relationalModelDefinition(false); ok {
 		r.Alias = d
 	} else if f, ok := relationalFieldDefinition(false); ok {
-		f.Alias = d
+		f.DatabaseFieldName = d
 	}
 }
 

--- a/example/app/contexts.go
+++ b/example/app/contexts.go
@@ -43,8 +43,8 @@ func NewCallbackAuthContext(ctx context.Context) (*CallbackAuthContext, error) {
 func (ctx *CallbackAuthContext) OK(resp []byte) error {
 	ctx.ResponseData.Header().Set("Content-Type", "text/html")
 	ctx.ResponseData.WriteHeader(200)
-	ctx.ResponseData.Write(resp)
-	return nil
+	_, err := ctx.ResponseData.Write(resp)
+	return err
 }
 
 // OauthAuthContext provides the auth oauth action context.
@@ -158,7 +158,7 @@ func NewCreateProposalContext(ctx context.Context) (*CreateProposalContext, erro
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -231,7 +231,7 @@ func NewDeleteProposalContext(ctx context.Context) (*DeleteProposalContext, erro
 	rawProposalID := req.Params.Get("proposalID")
 	if rawProposalID != "" {
 		if proposalID, err2 := strconv.Atoi(rawProposalID); err2 == nil {
-			rctx.ProposalID = int(proposalID)
+			rctx.ProposalID = proposalID
 		} else {
 			err = goa.InvalidParamTypeError("proposalID", rawProposalID, "integer", err)
 		}
@@ -239,7 +239,7 @@ func NewDeleteProposalContext(ctx context.Context) (*DeleteProposalContext, erro
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -276,7 +276,7 @@ func NewListProposalContext(ctx context.Context) (*ListProposalContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -308,7 +308,7 @@ func NewShowProposalContext(ctx context.Context) (*ShowProposalContext, error) {
 	rawProposalID := req.Params.Get("proposalID")
 	if rawProposalID != "" {
 		if proposalID, err2 := strconv.Atoi(rawProposalID); err2 == nil {
-			rctx.ProposalID = int(proposalID)
+			rctx.ProposalID = proposalID
 		} else {
 			err = goa.InvalidParamTypeError("proposalID", rawProposalID, "integer", err)
 		}
@@ -316,7 +316,7 @@ func NewShowProposalContext(ctx context.Context) (*ShowProposalContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -355,7 +355,7 @@ func NewUpdateProposalContext(ctx context.Context) (*UpdateProposalContext, erro
 	rawProposalID := req.Params.Get("proposalID")
 	if rawProposalID != "" {
 		if proposalID, err2 := strconv.Atoi(rawProposalID); err2 == nil {
-			rctx.ProposalID = int(proposalID)
+			rctx.ProposalID = proposalID
 		} else {
 			err = goa.InvalidParamTypeError("proposalID", rawProposalID, "integer", err)
 		}
@@ -363,7 +363,7 @@ func NewUpdateProposalContext(ctx context.Context) (*UpdateProposalContext, erro
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -445,7 +445,7 @@ func NewCreateReviewContext(ctx context.Context) (*CreateReviewContext, error) {
 	rawProposalID := req.Params.Get("proposalID")
 	if rawProposalID != "" {
 		if proposalID, err2 := strconv.Atoi(rawProposalID); err2 == nil {
-			rctx.ProposalID = int(proposalID)
+			rctx.ProposalID = proposalID
 		} else {
 			err = goa.InvalidParamTypeError("proposalID", rawProposalID, "integer", err)
 		}
@@ -453,7 +453,7 @@ func NewCreateReviewContext(ctx context.Context) (*CreateReviewContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -514,7 +514,7 @@ func NewDeleteReviewContext(ctx context.Context) (*DeleteReviewContext, error) {
 	rawProposalID := req.Params.Get("proposalID")
 	if rawProposalID != "" {
 		if proposalID, err2 := strconv.Atoi(rawProposalID); err2 == nil {
-			rctx.ProposalID = int(proposalID)
+			rctx.ProposalID = proposalID
 		} else {
 			err = goa.InvalidParamTypeError("proposalID", rawProposalID, "integer", err)
 		}
@@ -522,7 +522,7 @@ func NewDeleteReviewContext(ctx context.Context) (*DeleteReviewContext, error) {
 	rawReviewID := req.Params.Get("reviewID")
 	if rawReviewID != "" {
 		if reviewID, err2 := strconv.Atoi(rawReviewID); err2 == nil {
-			rctx.ReviewID = int(reviewID)
+			rctx.ReviewID = reviewID
 		} else {
 			err = goa.InvalidParamTypeError("reviewID", rawReviewID, "integer", err)
 		}
@@ -530,7 +530,7 @@ func NewDeleteReviewContext(ctx context.Context) (*DeleteReviewContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -568,7 +568,7 @@ func NewListReviewContext(ctx context.Context) (*ListReviewContext, error) {
 	rawProposalID := req.Params.Get("proposalID")
 	if rawProposalID != "" {
 		if proposalID, err2 := strconv.Atoi(rawProposalID); err2 == nil {
-			rctx.ProposalID = int(proposalID)
+			rctx.ProposalID = proposalID
 		} else {
 			err = goa.InvalidParamTypeError("proposalID", rawProposalID, "integer", err)
 		}
@@ -576,7 +576,7 @@ func NewListReviewContext(ctx context.Context) (*ListReviewContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -609,7 +609,7 @@ func NewShowReviewContext(ctx context.Context) (*ShowReviewContext, error) {
 	rawProposalID := req.Params.Get("proposalID")
 	if rawProposalID != "" {
 		if proposalID, err2 := strconv.Atoi(rawProposalID); err2 == nil {
-			rctx.ProposalID = int(proposalID)
+			rctx.ProposalID = proposalID
 		} else {
 			err = goa.InvalidParamTypeError("proposalID", rawProposalID, "integer", err)
 		}
@@ -617,7 +617,7 @@ func NewShowReviewContext(ctx context.Context) (*ShowReviewContext, error) {
 	rawReviewID := req.Params.Get("reviewID")
 	if rawReviewID != "" {
 		if reviewID, err2 := strconv.Atoi(rawReviewID); err2 == nil {
-			rctx.ReviewID = int(reviewID)
+			rctx.ReviewID = reviewID
 		} else {
 			err = goa.InvalidParamTypeError("reviewID", rawReviewID, "integer", err)
 		}
@@ -625,7 +625,7 @@ func NewShowReviewContext(ctx context.Context) (*ShowReviewContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -665,7 +665,7 @@ func NewUpdateReviewContext(ctx context.Context) (*UpdateReviewContext, error) {
 	rawProposalID := req.Params.Get("proposalID")
 	if rawProposalID != "" {
 		if proposalID, err2 := strconv.Atoi(rawProposalID); err2 == nil {
-			rctx.ProposalID = int(proposalID)
+			rctx.ProposalID = proposalID
 		} else {
 			err = goa.InvalidParamTypeError("proposalID", rawProposalID, "integer", err)
 		}
@@ -673,7 +673,7 @@ func NewUpdateReviewContext(ctx context.Context) (*UpdateReviewContext, error) {
 	rawReviewID := req.Params.Get("reviewID")
 	if rawReviewID != "" {
 		if reviewID, err2 := strconv.Atoi(rawReviewID); err2 == nil {
-			rctx.ReviewID = int(reviewID)
+			rctx.ReviewID = reviewID
 		} else {
 			err = goa.InvalidParamTypeError("reviewID", rawReviewID, "integer", err)
 		}
@@ -681,7 +681,7 @@ func NewUpdateReviewContext(ctx context.Context) (*UpdateReviewContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -752,8 +752,8 @@ func NewBootstrapUIContext(ctx context.Context) (*BootstrapUIContext, error) {
 func (ctx *BootstrapUIContext) OK(resp []byte) error {
 	ctx.ResponseData.Header().Set("Content-Type", "text/html")
 	ctx.ResponseData.WriteHeader(200)
-	ctx.ResponseData.Write(resp)
-	return nil
+	_, err := ctx.ResponseData.Write(resp)
+	return err
 }
 
 // CreateUserContext provides the user create action context.
@@ -830,7 +830,7 @@ func NewDeleteUserContext(ctx context.Context) (*DeleteUserContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -889,7 +889,7 @@ func NewShowUserContext(ctx context.Context) (*ShowUserContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}
@@ -927,7 +927,7 @@ func NewUpdateUserContext(ctx context.Context) (*UpdateUserContext, error) {
 	rawUserID := req.Params.Get("userID")
 	if rawUserID != "" {
 		if userID, err2 := strconv.Atoi(rawUserID); err2 == nil {
-			rctx.UserID = int(userID)
+			rctx.UserID = userID
 		} else {
 			err = goa.InvalidParamTypeError("userID", rawUserID, "integer", err)
 		}

--- a/example/models/proposal.go
+++ b/example/models/proposal.go
@@ -66,11 +66,11 @@ type ProposalStorage interface {
 	Update(ctx context.Context, proposal *Proposal) error
 	Delete(ctx context.Context, id int) error
 
-	ListAppProposal(ctx context.Context, userid int) []*app.Proposal
-	OneProposal(ctx context.Context, id int, userid int) (*app.Proposal, error)
+	ListAppProposal(ctx context.Context, userID int) []*app.Proposal
+	OneProposal(ctx context.Context, id int, userID int) (*app.Proposal, error)
 
-	ListAppProposalLink(ctx context.Context, userid int) []*app.ProposalLink
-	OneProposalLink(ctx context.Context, id int, userid int) (*app.ProposalLink, error)
+	ListAppProposalLink(ctx context.Context, userID int) []*app.ProposalLink
+	OneProposalLink(ctx context.Context, id int, userID int) (*app.ProposalLink, error)
 
 	UpdateFromCreateProposalPayload(ctx context.Context, payload *app.CreateProposalPayload, id int) error
 
@@ -87,10 +87,10 @@ func (m *ProposalDB) TableName() string {
 // Belongs To Relationships
 
 // ProposalFilterByUser is a gorm filter for a Belongs To relationship.
-func ProposalFilterByUser(userid int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
-	if userid > 0 {
+func ProposalFilterByUser(userID int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
+	if userID > 0 {
 		return func(db *gorm.DB) *gorm.DB {
-			return db.Where("user_id = ?", userid)
+			return db.Where("user_id = ?", userID)
 		}
 	}
 	return func(db *gorm.DB) *gorm.DB { return db }

--- a/example/models/proposal_helper.go
+++ b/example/models/proposal_helper.go
@@ -22,12 +22,12 @@ import (
 // MediaType Retrieval Functions
 
 // ListAppProposal returns an array of view: default.
-func (m *ProposalDB) ListAppProposal(ctx context.Context, userid int) []*app.Proposal {
+func (m *ProposalDB) ListAppProposal(ctx context.Context, userID int) []*app.Proposal {
 	defer goa.MeasureSince([]string{"goa", "db", "proposal", "listproposal"}, time.Now())
 
 	var native []*Proposal
 	var objs []*app.Proposal
-	err := m.Db.Scopes(ProposalFilterByUser(userid, &m.Db)).Table(m.TableName()).Preload("Reviews").Find(&native).Error
+	err := m.Db.Scopes(ProposalFilterByUser(userID, &m.Db)).Table(m.TableName()).Preload("Reviews").Find(&native).Error
 
 	if err != nil {
 		goa.Error(ctx, "error listing Proposal", goa.KV{"error", err.Error()})
@@ -61,11 +61,11 @@ func (m *Proposal) ProposalToAppProposal() *app.Proposal {
 }
 
 // OneProposal returns an array of view: default.
-func (m *ProposalDB) OneProposal(ctx context.Context, id int, userid int) (*app.Proposal, error) {
+func (m *ProposalDB) OneProposal(ctx context.Context, id int, userID int) (*app.Proposal, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "proposal", "oneproposal"}, time.Now())
 
 	var native Proposal
-	err := m.Db.Scopes(ProposalFilterByUser(userid, &m.Db)).Table(m.TableName()).Preload("Reviews").Preload("User").Where("id = ?", id).Find(&native).Error
+	err := m.Db.Scopes(ProposalFilterByUser(userID, &m.Db)).Table(m.TableName()).Preload("Reviews").Preload("User").Where("id = ?", id).Find(&native).Error
 
 	if err != nil && err != gorm.RecordNotFound {
 		goa.Error(ctx, "error getting Proposal", goa.KV{"error", err.Error()})
@@ -79,12 +79,12 @@ func (m *ProposalDB) OneProposal(ctx context.Context, id int, userid int) (*app.
 // MediaType Retrieval Functions
 
 // ListAppProposalLink returns an array of view: link.
-func (m *ProposalDB) ListAppProposalLink(ctx context.Context, userid int) []*app.ProposalLink {
+func (m *ProposalDB) ListAppProposalLink(ctx context.Context, userID int) []*app.ProposalLink {
 	defer goa.MeasureSince([]string{"goa", "db", "proposal", "listproposallink"}, time.Now())
 
 	var native []*Proposal
 	var objs []*app.ProposalLink
-	err := m.Db.Scopes(ProposalFilterByUser(userid, &m.Db)).Table(m.TableName()).Preload("Reviews").Find(&native).Error
+	err := m.Db.Scopes(ProposalFilterByUser(userID, &m.Db)).Table(m.TableName()).Preload("Reviews").Find(&native).Error
 
 	if err != nil {
 		goa.Error(ctx, "error listing Proposal", goa.KV{"error", err.Error()})
@@ -108,11 +108,11 @@ func (m *Proposal) ProposalToAppProposalLink() *app.ProposalLink {
 }
 
 // OneProposalLink returns an array of view: link.
-func (m *ProposalDB) OneProposalLink(ctx context.Context, id int, userid int) (*app.ProposalLink, error) {
+func (m *ProposalDB) OneProposalLink(ctx context.Context, id int, userID int) (*app.ProposalLink, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "proposal", "oneproposallink"}, time.Now())
 
 	var native Proposal
-	err := m.Db.Scopes(ProposalFilterByUser(userid, &m.Db)).Table(m.TableName()).Preload("Reviews").Preload("User").Where("id = ?", id).Find(&native).Error
+	err := m.Db.Scopes(ProposalFilterByUser(userID, &m.Db)).Table(m.TableName()).Preload("Reviews").Preload("User").Where("id = ?", id).Find(&native).Error
 
 	if err != nil && err != gorm.RecordNotFound {
 		goa.Error(ctx, "error getting Proposal", goa.KV{"error", err.Error()})

--- a/example/models/review.go
+++ b/example/models/review.go
@@ -65,11 +65,11 @@ type ReviewStorage interface {
 	Update(ctx context.Context, review *Review) error
 	Delete(ctx context.Context, id int) error
 
-	ListAppReview(ctx context.Context, proposalid int, userid int) []*app.Review
-	OneReview(ctx context.Context, id int, proposalid int, userid int) (*app.Review, error)
+	ListAppReview(ctx context.Context, proposalID int, userID int) []*app.Review
+	OneReview(ctx context.Context, id int, proposalID int, userID int) (*app.Review, error)
 
-	ListAppReviewLink(ctx context.Context, proposalid int, userid int) []*app.ReviewLink
-	OneReviewLink(ctx context.Context, id int, proposalid int, userid int) (*app.ReviewLink, error)
+	ListAppReviewLink(ctx context.Context, proposalID int, userID int) []*app.ReviewLink
+	OneReviewLink(ctx context.Context, id int, proposalID int, userID int) (*app.ReviewLink, error)
 
 	UpdateFromCreateReviewPayload(ctx context.Context, payload *app.CreateReviewPayload, id int) error
 
@@ -86,10 +86,10 @@ func (m *ReviewDB) TableName() string {
 // Belongs To Relationships
 
 // ReviewFilterByProposal is a gorm filter for a Belongs To relationship.
-func ReviewFilterByProposal(proposalid int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
-	if proposalid > 0 {
+func ReviewFilterByProposal(proposalID int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
+	if proposalID > 0 {
 		return func(db *gorm.DB) *gorm.DB {
-			return db.Where("proposal_id = ?", proposalid)
+			return db.Where("proposal_id = ?", proposalID)
 		}
 	}
 	return func(db *gorm.DB) *gorm.DB { return db }
@@ -98,10 +98,10 @@ func ReviewFilterByProposal(proposalid int, originaldb *gorm.DB) func(db *gorm.D
 // Belongs To Relationships
 
 // ReviewFilterByUser is a gorm filter for a Belongs To relationship.
-func ReviewFilterByUser(userid int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
-	if userid > 0 {
+func ReviewFilterByUser(userID int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
+	if userID > 0 {
 		return func(db *gorm.DB) *gorm.DB {
-			return db.Where("user_id = ?", userid)
+			return db.Where("user_id = ?", userID)
 		}
 	}
 	return func(db *gorm.DB) *gorm.DB { return db }

--- a/example/models/review_helper.go
+++ b/example/models/review_helper.go
@@ -22,12 +22,12 @@ import (
 // MediaType Retrieval Functions
 
 // ListAppReview returns an array of view: default.
-func (m *ReviewDB) ListAppReview(ctx context.Context, proposalid int, userid int) []*app.Review {
+func (m *ReviewDB) ListAppReview(ctx context.Context, proposalID int, userID int) []*app.Review {
 	defer goa.MeasureSince([]string{"goa", "db", "review", "listreview"}, time.Now())
 
 	var native []*Review
 	var objs []*app.Review
-	err := m.Db.Scopes(ReviewFilterByProposal(proposalid, &m.Db), ReviewFilterByUser(userid, &m.Db)).Table(m.TableName()).Find(&native).Error
+	err := m.Db.Scopes(ReviewFilterByProposal(proposalID, &m.Db), ReviewFilterByUser(userID, &m.Db)).Table(m.TableName()).Find(&native).Error
 
 	if err != nil {
 		goa.Error(ctx, "error listing Review", goa.KV{"error", err.Error()})
@@ -52,11 +52,11 @@ func (m *Review) ReviewToAppReview() *app.Review {
 }
 
 // OneReview returns an array of view: default.
-func (m *ReviewDB) OneReview(ctx context.Context, id int, proposalid int, userid int) (*app.Review, error) {
+func (m *ReviewDB) OneReview(ctx context.Context, id int, proposalID int, userID int) (*app.Review, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "review", "onereview"}, time.Now())
 
 	var native Review
-	err := m.Db.Scopes(ReviewFilterByProposal(proposalid, &m.Db), ReviewFilterByUser(userid, &m.Db)).Table(m.TableName()).Preload("Proposal").Preload("User").Where("id = ?", id).Find(&native).Error
+	err := m.Db.Scopes(ReviewFilterByProposal(proposalID, &m.Db), ReviewFilterByUser(userID, &m.Db)).Table(m.TableName()).Preload("Proposal").Preload("User").Where("id = ?", id).Find(&native).Error
 
 	if err != nil && err != gorm.RecordNotFound {
 		goa.Error(ctx, "error getting Review", goa.KV{"error", err.Error()})
@@ -70,12 +70,12 @@ func (m *ReviewDB) OneReview(ctx context.Context, id int, proposalid int, userid
 // MediaType Retrieval Functions
 
 // ListAppReviewLink returns an array of view: link.
-func (m *ReviewDB) ListAppReviewLink(ctx context.Context, proposalid int, userid int) []*app.ReviewLink {
+func (m *ReviewDB) ListAppReviewLink(ctx context.Context, proposalID int, userID int) []*app.ReviewLink {
 	defer goa.MeasureSince([]string{"goa", "db", "review", "listreviewlink"}, time.Now())
 
 	var native []*Review
 	var objs []*app.ReviewLink
-	err := m.Db.Scopes(ReviewFilterByProposal(proposalid, &m.Db), ReviewFilterByUser(userid, &m.Db)).Table(m.TableName()).Find(&native).Error
+	err := m.Db.Scopes(ReviewFilterByProposal(proposalID, &m.Db), ReviewFilterByUser(userID, &m.Db)).Table(m.TableName()).Find(&native).Error
 
 	if err != nil {
 		goa.Error(ctx, "error listing Review", goa.KV{"error", err.Error()})
@@ -98,11 +98,11 @@ func (m *Review) ReviewToAppReviewLink() *app.ReviewLink {
 }
 
 // OneReviewLink returns an array of view: link.
-func (m *ReviewDB) OneReviewLink(ctx context.Context, id int, proposalid int, userid int) (*app.ReviewLink, error) {
+func (m *ReviewDB) OneReviewLink(ctx context.Context, id int, proposalID int, userID int) (*app.ReviewLink, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "review", "onereviewlink"}, time.Now())
 
 	var native Review
-	err := m.Db.Scopes(ReviewFilterByProposal(proposalid, &m.Db), ReviewFilterByUser(userid, &m.Db)).Table(m.TableName()).Preload("Proposal").Preload("User").Where("id = ?", id).Find(&native).Error
+	err := m.Db.Scopes(ReviewFilterByProposal(proposalID, &m.Db), ReviewFilterByUser(userID, &m.Db)).Table(m.TableName()).Preload("Proposal").Preload("User").Where("id = ?", id).Find(&native).Error
 
 	if err != nil && err != gorm.RecordNotFound {
 		goa.Error(ctx, "error getting Review", goa.KV{"error", err.Error()})

--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -67,7 +67,7 @@ func (f RelationalModelDefinition) Children() []dslengine.Definition {
 func (f *RelationalModelDefinition) PKAttributes() string {
 	var attr []string
 	for _, pk := range f.PrimaryKeys {
-		attr = append(attr, fmt.Sprintf("%s %s", pk.DatabaseFieldName, goDatatype(pk, true)))
+		attr = append(attr, fmt.Sprintf("%s %s", codegen.Goify(pk.DatabaseFieldName, false), goDatatype(pk, true)))
 	}
 	return strings.Join(attr, ",")
 }
@@ -88,7 +88,7 @@ func (f *RelationalModelDefinition) PKWhere() string {
 func (f *RelationalModelDefinition) PKWhereFields() string {
 	var pkwhere []string
 	for _, pk := range f.PrimaryKeys {
-		def := fmt.Sprintf("%s", pk.DatabaseFieldName)
+		def := fmt.Sprintf("%s", codegen.Goify(pk.DatabaseFieldName, false))
 		pkwhere = append(pkwhere, def)
 	}
 	return strings.Join(pkwhere, ",")

--- a/writers.go
+++ b/writers.go
@@ -252,11 +252,7 @@ func viewSelect(ut *RelationalModelDefinition, v *design.ViewDefinition) string 
 			if strings.TrimSpace(name) != "" && name != "links" {
 				bf, ok := ut.RelationalFields[codegen.Goify(name, true)]
 				if ok {
-					if bf.Alias != "" {
-						fields = append(fields, bf.Alias)
-					} else {
-						fields = append(fields, bf.DatabaseFieldName)
-					}
+					fields = append(fields, bf.DatabaseFieldName)
 				}
 			}
 		}
@@ -529,7 +525,7 @@ func (m *{{$ut.ModelName}}DB) Delete(ctx context.Context{{ if $ut.DynamicTableNa
 
 	var obj {{$ut.ModelName}}{{ $l := len $ut.PrimaryKeys }}
 	{{ if eq $l 1 }}
-	err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Delete(&obj, id).Error
+	err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Delete(&obj, {{$ut.PKWhereFields}}).Error
 	{{ else  }}err := m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Delete(&obj).Where("{{$ut.PKWhere}}", {{$ut.PKWhereFields}}).Error
 	{{ end }}
 	if err != nil {
@@ -609,14 +605,14 @@ func (m *{{.Model.ModelName}}DB) List{{.VersionPackageName}}{{goify .Media.TypeN
 	}
 
 	for _, t := range native {
-		objs = append(objs, t.{{.Model.ModelName}}To{{.VersionPackageName}}{{.Media.UserTypeDefinition.TypeName}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}())
+		objs = append(objs, t.{{.Model.ModelName}}To{{.VersionPackageName}}{{goify .Media.UserTypeDefinition.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}())
 	}
 
 	return objs
 }
 
-// {{$.Model.ModelName}}To{{.VersionPackageName}}{{.Media.UserTypeDefinition.TypeName}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} returns the {{.VersionPackageName}} {{.Media.UserTypeDefinition.TypeName}} representation of {{$.Model.ModelName}}.
-func (m *{{.Model.ModelName}}) {{$.Model.ModelName}}To{{.VersionPackageName}}{{.Media.UserTypeDefinition.TypeName}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}() *{{.VersionPackage}}.{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} {
+// {{$.Model.ModelName}}To{{.VersionPackageName}}{{goify .Media.UserTypeDefinition.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} returns the {{.VersionPackageName}} {{goify .Media.UserTypeDefinition.TypeName true}} representation of {{$.Model.ModelName}}.
+func (m *{{.Model.ModelName}}) {{$.Model.ModelName}}To{{.VersionPackageName}}{{goify .Media.UserTypeDefinition.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}() *{{.VersionPackage}}.{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} {
 	{{.Model.LowerName}} := &{{.VersionPackage}}.{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}{}
  	{{ famt .Model .View .VersionPackageName "m" "m" .Model.LowerName}}
 

--- a/writers.go
+++ b/writers.go
@@ -425,8 +425,8 @@ type {{$ut.ModelName}}Storage interface {
 	Delete(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{ $ut.PKAttributes}}) (error)
 {{ range $rname, $rmt := $ut.RenderTo }}{{ range $vname, $view := $rmt.Views}}{{ $mtd := $ut.Project $rname $vname }}{{$vp := vp "app"}}{{$vpn := goify $vp true}}
 {{ if $rmt.UserTypeDefinition.SupportsNoVersion }}
-	List{{$vpn}}{{goify $rmt.TypeName true}}{{if eq $vname "default"}}{{else}}{{goify $vname true}}{{end}} (ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }} {{range $nm, $bt := $ut.BelongsTo}},{{goify $bt.ModelName false}}id int{{end}}) []*{{goify $vpn false}}.{{goify $rmt.TypeName true}}{{if eq $vname "default"}}{{else}}{{goify $vname true}}{{end}}
-	One{{goify $rmt.TypeName true}}{{if eq $vname "default"}}{{else}}{{goify $vname true}}{{end}} (ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}, {{$ut.PKAttributes}}{{range $nm, $bt := $ut.BelongsTo}},{{goify $bt.ModelName false}}id int{{end}}) (*{{goify $vpn false}}.{{goify $rmt.TypeName true}}{{if eq $vname "default"}}{{else}}{{goify $vname true}}{{end}}, error)
+	List{{$vpn}}{{goify $rmt.TypeName true}}{{if eq $vname "default"}}{{else}}{{goify $vname true}}{{end}} (ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }} {{range $nm, $bt := $ut.BelongsTo}},{{goify (printf "%s%s" $bt.ModelName "ID") false}} int{{end}}) []*{{goify $vpn false}}.{{goify $rmt.TypeName true}}{{if eq $vname "default"}}{{else}}{{goify $vname true}}{{end}}
+	One{{goify $rmt.TypeName true}}{{if eq $vname "default"}}{{else}}{{goify $vname true}}{{end}} (ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}, {{$ut.PKAttributes}}{{range $nm, $bt := $ut.BelongsTo}},{{goify (printf "%s%s" $bt.ModelName "ID") false}} int{{end}}) (*{{goify $vpn false}}.{{goify $rmt.TypeName true}}{{if eq $vname "default"}}{{else}}{{goify $vname true}}{{end}}, error)
 {{ end }}
 {{ range $version :=  $rmt.Versions }} {{$vp := vp $version}}{{$vpn := goify $vp true}}
 // {{$version}} I don't remember why I put this here.  Don't delete until I remember.  What versioned things might we add to the Interface?
@@ -448,10 +448,10 @@ func (m *{{$ut.ModelName}}DB) TableName() string {
 // Belongs To Relationships
 
 // {{$ut.ModelName}}FilterBy{{$bt.ModelName}} is a gorm filter for a Belongs To relationship.
-func {{$ut.ModelName}}FilterBy{{$bt.ModelName}}({{goify $bt.ModelName false}}id int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
-	if {{goify $bt.ModelName false}}id > 0 {
+func {{$ut.ModelName}}FilterBy{{$bt.ModelName}}({{goify (printf "%s%s" $bt.ModelName "ID") false}} int, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
+	if {{goify (printf "%s%s" $bt.ModelName "ID") false}} > 0 {
 		return func(db *gorm.DB) *gorm.DB {
-			return db.Where("{{$bt.LowerName}}_id = ?", {{goify $bt.ModelName false}}id)
+			return db.Where("{{$bt.LowerName}}_id = ?", {{goify (printf "%s%s" $bt.ModelName "ID") false}})
 		}
 	}
 	return func(db *gorm.DB) *gorm.DB { return db }
@@ -592,12 +592,12 @@ func (m {{$ut.ModelName}}) GetRole() string {
 	mediaVersionT = `// MediaType Retrieval Functions
 
 // List{{.VersionPackageName}}{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} returns an array of view: {{.ViewName}}.
-func (m *{{.Model.ModelName}}DB) List{{.VersionPackageName}}{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} (ctx context.Context{{ if .Model.DynamicTableName}}, tableName string{{ end }} {{range $nm, $bt := .Model.BelongsTo}},{{goify $bt.ModelName false}}id int{{end}}) []*{{.VersionPackage}}.{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}{
+func (m *{{.Model.ModelName}}DB) List{{.VersionPackageName}}{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} (ctx context.Context{{ if .Model.DynamicTableName}}, tableName string{{ end }} {{range $nm, $bt := .Model.BelongsTo}},{{goify (printf "%s%s" $bt.ModelName "ID") false}} int{{end}}) []*{{.VersionPackage}}.{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}{
 	defer goa.MeasureSince([]string{"goa","db","{{goify .Media.TypeName false}}", "list{{goify .Media.TypeName false}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName false}}{{end}}"}, time.Now())
 
 	var native []*{{goify .Model.ModelName true}}
 	var objs []*{{.VersionPackage}}.{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} {{$ctx:= .}}
-	err := m.Db.Scopes({{range $nm, $bt := .Model.BelongsTo}}{{$ctx.Model.ModelName}}FilterBy{{goify $bt.ModelName true}}({{goify $bt.ModelName false}}id, &m.Db), {{end}}).Table({{ if .Model.DynamicTableName }}tableName{{else}}m.TableName(){{ end }}).{{ range $ln, $lv := .Media.Links }}Preload("{{goify $ln true}}").{{end}}Find(&native).Error
+	err := m.Db.Scopes({{range $nm, $bt := .Model.BelongsTo}}{{$ctx.Model.ModelName}}FilterBy{{goify $bt.ModelName true}}({{goify (printf "%s%s" $bt.ModelName "ID") false}}, &m.Db), {{end}}).Table({{ if .Model.DynamicTableName }}tableName{{else}}m.TableName(){{ end }}).{{ range $ln, $lv := .Media.Links }}Preload("{{goify $ln true}}").{{end}}Find(&native).Error
 {{/* //	err := m.Db.Table({{ if .Model.DynamicTableName }}tableName{{else}}m.TableName(){{ end }}).{{ range $ln, $lv := .Media.Links }}Preload("{{goify $ln true}}").{{end}}Find(&objs).Error */}}
 	if err != nil {
 		goa.Error(ctx, "error listing {{.Model.ModelName}}", goa.KV{"error", err.Error()})
@@ -620,11 +620,11 @@ func (m *{{.Model.ModelName}}) {{$.Model.ModelName}}To{{.VersionPackageName}}{{g
 }
 
 // One{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} returns an array of view: {{.ViewName}}{{$ut := .Model}}.
-func (m *{{.Model.ModelName}}DB) One{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} (ctx context.Context{{ if .Model.DynamicTableName}}, tableName string{{ end }},{{.Model.PKAttributes}}{{range $nm, $bt := .Model.BelongsTo}},{{goify $bt.ModelName false}}id int{{end}}) (*{{.VersionPackage}}.{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}, error){
+func (m *{{.Model.ModelName}}DB) One{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}} (ctx context.Context{{ if .Model.DynamicTableName}}, tableName string{{ end }},{{.Model.PKAttributes}}{{range $nm, $bt := .Model.BelongsTo}},{{goify (printf "%s%s" $bt.ModelName "ID") false}} int{{end}}) (*{{.VersionPackage}}.{{goify .Media.TypeName true}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName true}}{{end}}, error){
 	defer goa.MeasureSince([]string{"goa","db","{{goify .Media.TypeName false}}", "one{{goify .Media.TypeName false}}{{if eq .ViewName "default"}}{{else}}{{goify .ViewName false}}{{end}}"}, time.Now())
 
 	var native {{.Model.ModelName}}
-	err := m.Db.Scopes({{range $nm, $bt := .Model.BelongsTo}}{{$ctx.Model.ModelName}}FilterBy{{goify $bt.ModelName true}}({{goify $bt.ModelName false}}id, &m.Db), {{end}}).Table({{ if .Model.DynamicTableName }}tableName{{else}}m.TableName(){{ end }}){{range $na, $hm:= .Model.HasMany}}.Preload("{{plural $hm.ModelName}}"){{end}}{{range $nm, $bt := .Model.BelongsTo}}.Preload("{{$bt.ModelName}}"){{end}}.Where("{{.Model.PKWhere}}",{{.Model.PKWhereFields}}).Find(&native).Error
+	err := m.Db.Scopes({{range $nm, $bt := .Model.BelongsTo}}{{$ctx.Model.ModelName}}FilterBy{{goify $bt.ModelName true}}({{goify (printf "%s%s" $bt.ModelName "ID") false}}, &m.Db), {{end}}).Table({{ if .Model.DynamicTableName }}tableName{{else}}m.TableName(){{ end }}){{range $na, $hm:= .Model.HasMany}}.Preload("{{plural $hm.ModelName}}"){{end}}{{range $nm, $bt := .Model.BelongsTo}}.Preload("{{$bt.ModelName}}"){{end}}.Where("{{.Model.PKWhere}}",{{.Model.PKWhereFields}}).Find(&native).Error
 
 	if err != nil && err != gorm.RecordNotFound {
 		goa.Error(ctx, "error getting {{.Model.ModelName}}", goa.KV{"error", err.Error()})


### PR DESCRIPTION
This commit removes the RelationalFieldDefinition.Alias field and uses the
existing DatabaseFieldName.  In fixing this issue, I replaced Underscore with a
solution that does proper snake_case.

I also sneek in a few fixes for the templates to goify a TypeName.