### PR TITLE
Security

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -73,6 +73,7 @@ type RelationalModelDefinition struct {
 	Cached           bool
 	CacheDuration    int
 	Roler            bool
+	DefaultRole      string
 	DynamicTableName bool
 	SQLTag           string
 	RelationalFields map[string]*RelationalFieldDefinition

--- a/definitions.go
+++ b/definitions.go
@@ -32,6 +32,24 @@ type RelationalStoreDefinition struct {
 	NoAutoIDFields   bool
 	NoAutoTimestamps bool
 	NoAutoSoftDelete bool
+	Roles            *RolesDefinition
+}
+
+// RolesDefinition defines a list of roles
+type RolesDefinition struct {
+	dslengine.Definition
+	Parent        *RelationalStoreDefinition
+	DefinitionDSL func()
+	Roles         map[string]*RoleDefinition
+}
+
+// RoleDefinition defines a named group of scopes
+type RoleDefinition struct {
+	dslengine.Definition
+	DefinitionDSL func()
+	Parent        *RolesDefinition
+	Name          string
+	Scopes        []string
 }
 
 // RelationalModelDefinition implements the storage of a domain model into a
@@ -159,6 +177,10 @@ type StoreIterator func(m *RelationalStoreDefinition) error
 // ModelIterator is a function that iterates over Models in a
 // RelationalStore.
 type ModelIterator func(m *RelationalModelDefinition) error
+
+// RoleIterator is a function that iterates over Roles in a
+// RelationalStore
+type RoleIterator func(m *RoleDefinition) error
 
 // FieldIterator is a function that iterates over Fields
 // in a RelationalModel.

--- a/dsl/relationalmodel.go
+++ b/dsl/relationalmodel.go
@@ -351,18 +351,31 @@ func Cached(d string) {
 	}
 }
 
-// Roler sets a boolean flag that cause the generation of a
-// Role() function that returns the model's Role value
-// Creates a "Role" field in the table if it doesn't already exist
-// as a string type
-func Roler() {
+// Roler causes this model to satisfy the Roler() interface
+// Usage:
+//     Roler("Admin") // Default role = Admin, field name = "role"
+//     Roler("Admin","user_role") // Default role = Admin, field name = "user_role"
+func Roler(args ...string) {
 	if r, ok := relationalModelDefinition(false); ok {
 		r.Roler = true
-		if _, ok := r.RelationalFields["Role"]; !ok {
+		var fn, defRole string
+		if len(args) == 1 {
+			fn = "Role"
+			defRole = args[0]
+		} else if len(args) == 2 {
+			fn = args[1]
+			defRole = args[0]
+		} else if len(args) > 2 {
+			dslengine.ReportError("Roler requires 1 or 2 arguments.")
+			return
+		}
+		r.DefaultRole = defRole
+		if _, ok := r.RelationalFields[fn]; !ok {
 			field := gorma.NewRelationalFieldDefinition()
-			field.FieldName = "Role"
+			field.FieldName = SanitizeFieldName(fn)
+			field.DatabaseFieldName = SanitizeDBFieldName(fn)
 			field.Datatype = gorma.String
-			r.RelationalFields["Role"] = field
+			r.RelationalFields[fn] = field
 		}
 	}
 }

--- a/dsl/relationalmodel_test.go
+++ b/dsl/relationalmodel_test.go
@@ -251,6 +251,60 @@ var _ = Describe("RelationalModel", func() {
 			})
 		})
 
+		Context("with roler and one parameter", func() {
+
+			BeforeEach(func() {
+				name = "Users"
+				dsl = func() {
+					gdsl.Roler("Admin")
+				}
+			})
+
+			It("Creates a Role field", func() {
+				sg := gorma.GormaDesign
+				rs := sg.RelationalStores[storename]
+				Ω(rs.RelationalModels[name].Roler).Should(Equal(true))
+			})
+
+			It("Sets default role", func() {
+				sg := gorma.GormaDesign
+				rs := sg.RelationalStores[storename]
+				Ω(rs.RelationalModels[name].DefaultRole).Should(Equal("Admin"))
+			})
+			It("correctly names default role", func() {
+				sg := gorma.GormaDesign
+				rs := sg.RelationalStores[storename]
+				Ω(rs.RelationalModels[name].DefaultRole).ShouldNot(Equal("Blue"))
+			})
+		})
+		Context("with roler and two parameters", func() {
+
+			BeforeEach(func() {
+				name = "Users"
+				dsl = func() {
+					gdsl.Roler("UserAdmin", "user_role")
+				}
+			})
+
+			It("Creates a Role field", func() {
+				sg := gorma.GormaDesign
+				rs := sg.RelationalStores[storename]
+				Ω(rs.RelationalModels[name].Roler).Should(Equal(true))
+			})
+
+			It("Sets default role", func() {
+				sg := gorma.GormaDesign
+				rs := sg.RelationalStores[storename]
+				Ω(rs.RelationalModels[name].DefaultRole).Should(Equal("UserAdmin"))
+			})
+			It("correctly names default role field", func() {
+				sg := gorma.GormaDesign
+				rs := sg.RelationalStores[storename]
+				_, ok := rs.RelationalModels[name].RelationalFields["user_role"]
+				Ω(ok).Should(BeTrue())
+			})
+		})
+
 		Context("with dynamic table name", func() {
 
 			BeforeEach(func() {

--- a/dsl/relationalstore.go
+++ b/dsl/relationalstore.go
@@ -83,7 +83,7 @@ func NoAutomaticSoftDelete() {
 // Usage:
 //        Roles(func() {
 //            Role("Admin", func() {
-//                Scope("myscope:mysubscope")
+//                AllowedScope("myscope:mysubscope")
 //            })
 //        })
 func Roles(dsl func()) {
@@ -105,9 +105,9 @@ func Role(name string, dsl func()) {
 
 }
 
-// Scope is a named permission that can be checked
+// AllowedScope is a named permission that can be checked
 // at the API, Resource, and Action level
-func Scope(name string) {
+func AllowedScope(name string) {
 	if role, ok := roleDefinition(true); ok {
 		role.Scopes = append(role.Scopes, name)
 	}

--- a/dsl/relationalstore.go
+++ b/dsl/relationalstore.go
@@ -33,6 +33,7 @@ func Store(name string, storeType gorma.RelationalStorageType, dsl func()) {
 				Parent:           s,
 				Type:             storeType,
 				RelationalModels: make(map[string]*gorma.RelationalModelDefinition),
+				Roles:            gorma.NewRolesDefinition(),
 			}
 		} else {
 			dslengine.ReportError("Relational Store %s can only be declared once.", name)
@@ -75,4 +76,40 @@ func NoAutomaticSoftDelete() {
 	} else if m, ok := relationalModelDefinition(false); ok {
 		delete(m.RelationalFields, "DeletedAt")
 	}
+}
+
+// Roles defines a list of named roles and the scopes that are
+// assigned to each role.
+// Usage:
+//        Roles(func() {
+//            Role("Admin", func() {
+//                Scope("myscope:mysubscope")
+//            })
+//        })
+func Roles(dsl func()) {
+	if sd, ok := relationalStoreDefinition(true); ok {
+		rd := sd.Roles
+		rd.DefinitionDSL = dsl
+	}
+}
+
+// Role is a named set of scopes that can be applied
+// to a user
+func Role(name string, dsl func()) {
+	if roles, ok := rolesDefinition(true); ok {
+		rd := gorma.NewRoleDefinition()
+		rd.DefinitionDSL = dsl
+		rd.Name = name
+		roles.Roles[name] = rd
+	}
+
+}
+
+// Scope is a named permission that can be checked
+// at the API, Resource, and Action level
+func Scope(name string) {
+	if role, ok := roleDefinition(true); ok {
+		role.Scopes = append(role.Scopes, name)
+	}
+
 }

--- a/dsl/relationalstore_test.go
+++ b/dsl/relationalstore_test.go
@@ -166,7 +166,7 @@ var _ = Describe("RelationalStore", func() {
 			})
 		})
 
-		Context("with Roles", func() {
+		Context("with one Role", func() {
 			BeforeEach(func() {
 				name = "mysql"
 				dsl = func() {
@@ -188,6 +188,47 @@ var _ = Describe("RelationalStore", func() {
 				admin := sg.RelationalStores[name].Roles.Roles["Admin"]
 				Ω(len(admin.Scopes)).Should(Equal(2))
 			})
+		})
+
+		Context("with more than one Role", func() {
+			BeforeEach(func() {
+				name = "mysql"
+				dsl = func() {
+					gdsl.Roles(func() {
+						gdsl.Role("Admin", func() {
+							gdsl.Scope("scope:1")
+							gdsl.Scope("scope:2")
+						})
+						gdsl.Role("User", func() {
+							gdsl.Scope("scope:3")
+							gdsl.Scope("scope:4")
+							gdsl.Scope("scope:5")
+							gdsl.Scope("scope:6")
+						})
+					})
+				}
+			})
+
+			It("generates a role", func() {
+				sg := gorma.GormaDesign
+				Ω(len(sg.RelationalStores[name].Roles.Roles)).ShouldNot(BeZero())
+			})
+			It("has admin scopes", func() {
+				sg := gorma.GormaDesign
+				admin := sg.RelationalStores[name].Roles.Roles["Admin"]
+				Ω(len(admin.Scopes)).Should(Equal(2))
+			})
+			It("has user scopes", func() {
+				sg := gorma.GormaDesign
+				usr := sg.RelationalStores[name].Roles.Roles["User"]
+				Ω(len(usr.Scopes)).Should(Equal(4))
+			})
+			It("contains user scopes", func() {
+				sg := gorma.GormaDesign
+				usr := sg.RelationalStores[name].Roles.Roles["User"]
+				Ω(usr.Scopes).Should(ContainElement("scope:6"))
+			})
+
 		})
 
 	})

--- a/dsl/relationalstore_test.go
+++ b/dsl/relationalstore_test.go
@@ -172,8 +172,8 @@ var _ = Describe("RelationalStore", func() {
 				dsl = func() {
 					gdsl.Roles(func() {
 						gdsl.Role("Admin", func() {
-							gdsl.Scope("scope:1")
-							gdsl.Scope("scope:2")
+							gdsl.AllowedScope("scope:1")
+							gdsl.AllowedScope("scope:2")
 						})
 					})
 				}
@@ -196,14 +196,14 @@ var _ = Describe("RelationalStore", func() {
 				dsl = func() {
 					gdsl.Roles(func() {
 						gdsl.Role("Admin", func() {
-							gdsl.Scope("scope:1")
-							gdsl.Scope("scope:2")
+							gdsl.AllowedScope("scope:1")
+							gdsl.AllowedScope("scope:2")
 						})
 						gdsl.Role("User", func() {
-							gdsl.Scope("scope:3")
-							gdsl.Scope("scope:4")
-							gdsl.Scope("scope:5")
-							gdsl.Scope("scope:6")
+							gdsl.AllowedScope("scope:3")
+							gdsl.AllowedScope("scope:4")
+							gdsl.AllowedScope("scope:5")
+							gdsl.AllowedScope("scope:6")
 						})
 					})
 				}

--- a/dsl/relationalstore_test.go
+++ b/dsl/relationalstore_test.go
@@ -166,6 +166,30 @@ var _ = Describe("RelationalStore", func() {
 			})
 		})
 
+		Context("with Roles", func() {
+			BeforeEach(func() {
+				name = "mysql"
+				dsl = func() {
+					gdsl.Roles(func() {
+						gdsl.Role("Admin", func() {
+							gdsl.Scope("scope:1")
+							gdsl.Scope("scope:2")
+						})
+					})
+				}
+			})
+
+			It("generates a role", func() {
+				sg := gorma.GormaDesign
+				Ω(len(sg.RelationalStores[name].Roles.Roles)).ShouldNot(BeZero())
+			})
+			It("has scopes", func() {
+				sg := gorma.GormaDesign
+				admin := sg.RelationalStores[name].Roles.Roles["Admin"]
+				Ω(len(admin.Scopes)).Should(Equal(2))
+			})
+		})
+
 	})
 
 })

--- a/dsl/runner.go
+++ b/dsl/runner.go
@@ -70,3 +70,23 @@ func attributeDefinition(failIfNotSD bool) (*design.AttributeDefinition, bool) {
 	}
 	return a, ok
 }
+
+// roleDefinition returns true and current context if it is a RoleDefinition
+// nil and false otherwise.
+func roleDefinition(failIfNotSD bool) (*gorma.RoleDefinition, bool) {
+	a, ok := dslengine.CurrentDefinition().(*gorma.RoleDefinition)
+	if !ok && failIfNotSD {
+		dslengine.IncompatibleDSL()
+	}
+	return a, ok
+}
+
+// rolesDefinition returns true and current context if it is a RolesDefinition
+// nil and false otherwise.
+func rolesDefinition(failIfNotSD bool) (*gorma.RolesDefinition, bool) {
+	a, ok := dslengine.CurrentDefinition().(*gorma.RolesDefinition)
+	if !ok && failIfNotSD {
+		dslengine.IncompatibleDSL()
+	}
+	return a, ok
+}

--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -38,7 +38,7 @@ func NewRelationalModelDefinition() *RelationalModelDefinition {
 // Context returns the generic definition name used in error messages.
 func (f *RelationalModelDefinition) Context() string {
 	if f.ModelName != "" {
-		return fmt.Sprintf("RelationalModel %#v", f.Name)
+		return fmt.Sprintf("RelationalModel %#v", f.ModelName)
 	}
 	return "unnamed RelationalModel"
 }

--- a/relationalmodel_test.go
+++ b/relationalmodel_test.go
@@ -13,7 +13,7 @@ func TestModelContext(t *testing.T) {
 	sg.ModelName = "SG"
 
 	c := sg.Context()
-	exp := fmt.Sprintf("RelationalModel %#v", sg.Name)
+	exp := fmt.Sprintf("RelationalModel %#v", sg.ModelName)
 	if c != exp {
 		t.Errorf("Expected %s, got %s", exp, c)
 	}

--- a/relationalstore.go
+++ b/relationalstore.go
@@ -54,3 +54,20 @@ func (sd *RelationalStoreDefinition) IterateModels(it ModelIterator) error {
 	}
 	return nil
 }
+
+// IterateRoles runs an iterator function once per Role in the Store's roles list.
+func (sd *RelationalStoreDefinition) IterateRoles(it RoleIterator) error {
+	names := make([]string, len(sd.Roles.Roles))
+	i := 0
+	for n := range sd.Roles.Roles {
+		names[i] = n
+		i++
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		if err := it(sd.Roles.Roles[n]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/role.go
+++ b/role.go
@@ -1,0 +1,22 @@
+package gorma
+
+import "fmt"
+
+// NewRoleDefinition returns an initialized RoleDefinition
+func NewRoleDefinition() *RoleDefinition {
+	r := &RoleDefinition{}
+	return r
+}
+
+// Context returns the generic definition name used in error messages.
+func (f *RoleDefinition) Context() string {
+	if f.Name != "" {
+		return fmt.Sprintf("RoleDefinition %#v", f.Name)
+	}
+	return "unnamed RoleDefinition"
+}
+
+// DSL returns this object's DSL.
+func (f *RoleDefinition) DSL() func() {
+	return f.DefinitionDSL
+}

--- a/roles.go
+++ b/roles.go
@@ -1,0 +1,18 @@
+package gorma
+
+// NewRolesDefinition returns an initialized RoleDefinition
+func NewRolesDefinition() *RolesDefinition {
+	r := &RolesDefinition{}
+	r.Roles = make(map[string]*RoleDefinition)
+	return r
+}
+
+// Context returns the generic definition name used in error messages.
+func (f *RolesDefinition) Context() string {
+	return "unnamed RolesDefinition"
+}
+
+// DSL returns this object's DSL.
+func (f *RolesDefinition) DSL() func() {
+	return f.DefinitionDSL
+}

--- a/storagegroup.go
+++ b/storagegroup.go
@@ -80,6 +80,11 @@ func (sd *StorageGroupDefinition) IterateSets(iterator dslengine.SetIterator) {
 	iterator([]dslengine.Definition{sd})
 	sd.IterateStores(func(store *RelationalStoreDefinition) error {
 		iterator([]dslengine.Definition{store})
+		iterator([]dslengine.Definition{store.Roles})
+		store.IterateRoles(func(role *RoleDefinition) error {
+			iterator([]dslengine.Definition{role})
+			return nil
+		})
 		store.IterateModels(func(model *RelationalModelDefinition) error {
 			iterator([]dslengine.Definition{model})
 			model.IterateFields(func(field *RelationalFieldDefinition) error {
@@ -93,6 +98,7 @@ func (sd *StorageGroupDefinition) IterateSets(iterator dslengine.SetIterator) {
 
 			return nil
 		})
+
 		return nil
 	})
 }


### PR DESCRIPTION
This PR is meant to coincide with the goa PR that introduces a new security DSL.

It generates code that creates Role constants, with a list of scopes assigned to each Role.
It also generates the required fields in a User model to get the roles that a User belongs to for adding to the JWT token.