### PR TITLE
Add primitive support for UUID primary keys.

### DIFF
--- a/dsl/relationalfield.go
+++ b/dsl/relationalfield.go
@@ -108,9 +108,8 @@ func Nullable() {
 // Valid only for `Integer` datatypes currently
 func PrimaryKey() {
 	if f, ok := relationalFieldDefinition(true); ok {
-		if f.Datatype != gorma.Integer {
+		if f.Datatype != gorma.Integer && f.Datatype != gorma.UUID {
 			dslengine.ReportError("Integer is the only supported Primary Key field type for now.")
-
 		}
 
 		f.PrimaryKey = true

--- a/generator.go
+++ b/generator.go
@@ -146,6 +146,7 @@ func (g *Generator) generateUserTypes(outdir string, api *design.APIDefinition) 
 				codegen.SimpleImport("github.com/jinzhu/gorm"),
 				codegen.SimpleImport("golang.org/x/net/context"),
 				codegen.SimpleImport("golang.org/x/net/context"),
+				codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 			}
 
 			if model.Cached {
@@ -208,6 +209,7 @@ func (g *Generator) generateUserHelpers(outdir string, api *design.APIDefinition
 				codegen.SimpleImport("github.com/jinzhu/gorm"),
 				codegen.SimpleImport("golang.org/x/net/context"),
 				codegen.SimpleImport("golang.org/x/net/context"),
+				codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 			}
 
 			if model.Cached {

--- a/relationalfield.go
+++ b/relationalfield.go
@@ -100,7 +100,7 @@ func goDatatype(f *RelationalFieldDefinition, includePtr bool) string {
 	case Text:
 		return ptr + "string"
 	case UUID:
-		return ptr + "string" // what to do about UUIDS?
+		return ptr + "uuid.UUID"
 	case Timestamp, NullableTimestamp:
 		return ptr + "time.Time"
 	case BelongsTo:

--- a/relationalfield_test.go
+++ b/relationalfield_test.go
@@ -54,6 +54,7 @@ func TestFieldDefinitions(t *testing.T) {
 		expected    string
 	}{
 		{"id", gorma.Integer, "description", false, "", "", "", "", "ID\tint  // description\n"},
+		{"id", gorma.UUID, "description", false, "", "", "", "", "ID\tuuid.UUID  // description\n"},
 		{"name", gorma.String, "name", true, "", "", "", "", "Name\t*string  // name\n"},
 		{"user", gorma.HasOne, "has one", false, "", "", "User", "", "User\tUser  // has one\n"},
 		{"user_id", gorma.BelongsTo, "belongs to", false, "", "", "", "", "UserID\tint  // belongs to\n"},


### PR DESCRIPTION
Using the often referenced uuid in the gorm issues. Currently, it is using `char(36)` this could be optimized later for MySQL by marshalling the uuid to and from a `binary(16)` field. As for postgres, just drop in `SQLTag("type:uuid") below `PrimaryKey()` and you are all set.

Pairing goa PR will be up once I review it again tomorrow.