### PR TITLE
check for go keywords when calling LowerName()

### DIFF
--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -146,7 +146,7 @@ func (f *RelationalModelDefinition) Project(name, v string) *design.MediaTypeDef
 
 // LowerName returns the model name as a lowercase string.
 func (f *RelationalModelDefinition) LowerName() string {
-	return strings.ToLower(f.ModelName)
+	return codegen.Goify(strings.ToLower(f.ModelName), false)
 }
 
 // IterateBuildSources runs an iterator function once per Model in the Store's model list.


### PR DESCRIPTION
I want to name my model `Interface` but the methods that would be generated in `models/interface.go` end up writing a couple methods with the following syntax:
`Add(ctx context.Context, interface *Interface) (*Interface, error)`
As you can see, `interface` cannot be the parameter name. Goify wasn't being called on `LowerName()` to make this possible. I made that change to make it possible.