### PR TITLE
WIP Update to use channels for DB execution (opinions welcome! :)

### DIFF
--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -72,6 +72,16 @@ func (f *RelationalModelDefinition) PKAttributes() string {
 	return strings.Join(attr, ",")
 }
 
+// PKAttributeNames constructs a field strings
+// useful for calling method parameters.
+func (f *RelationalModelDefinition) PKAttributeNames() string {
+	var attr []string
+	for _, pk := range f.PrimaryKeys {
+		attr = append(attr, fmt.Sprintf("%s", codegen.Goify(pk.DatabaseFieldName, false)))
+	}
+	return strings.Join(attr, ",")
+}
+
 // PKWhere returns an array of strings representing the where clause
 // of a retrieval by primary key(s) -- x = ? and y = ?.
 func (f *RelationalModelDefinition) PKWhere() string {

--- a/writers.go
+++ b/writers.go
@@ -396,6 +396,25 @@ func (m {{$ut.ModelName}}) TableName() string {
 return "{{ $ut.Alias}}" {{ else }} return "{{ $ut.TableName }}"
 {{end}}
 }
+
+// {{$ut.ModelName}}Result represents a {{$ut.ModelName}} result passed over a channel
+type {{$ut.ModelName}}Result struct {
+	Data {{$ut.ModelName}}
+	Err error
+}
+
+// {{$ut.ModelName}}ListResult represents a []{{$ut.ModelName}} result passed over a channel
+type {{$ut.ModelName}}ListResult struct {
+	Data []{{$ut.ModelName}}
+	Err error
+}
+
+// {{$ut.ModelName}}Channel used to pass async {{$ut.ModelName}} results from DB
+type {{$ut.ModelName}}Channel chan {{$ut.ModelName}}Result
+
+// {{$ut.ModelName}}ListChannel used to pass async []{{$ut.ModelName}} results from DB
+type {{$ut.ModelName}}ListChannel chan {{$ut.ModelName}}ListResult
+
 // {{$ut.ModelName}}DB is the implementation of the storage interface for
 // {{$ut.ModelName}}.
 type {{$ut.ModelName}}DB struct {
@@ -423,6 +442,12 @@ type {{$ut.ModelName}}Storage interface {
 	Add(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}} *{{$ut.ModelName}}) (*{{$ut.ModelName}}, error)
 	Update(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}} *{{$ut.ModelName}}) (error)
 	Delete(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{ $ut.PKAttributes}}) (error)
+
+	ListAsync(ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}) {{$ut.ModelName}}ListChannel
+	GetAsync(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}}) {{$ut.ModelName}}Channel
+	AddAsync(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}} *{{$ut.ModelName}}) {{$ut.ModelName}}Channel
+	UpdateAsync(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}} *{{$ut.ModelName}}) {{$ut.ModelName}}Channel
+	DeleteAsync(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{ $ut.PKAttributes}}) {{$ut.ModelName}}Channel
 {{range $rname, $rmt := $ut.RenderTo}}{{/*
 
 */}}{{range $vname, $view := $rmt.Views}}{{ $mtd := $ut.Project $rname $vname }}
@@ -478,6 +503,23 @@ func (m *{{$ut.ModelName}}DB) Get(ctx context.Context{{ if $ut.DynamicTableName}
 	return native, err
 }
 
+// GetAsync returns a single {{$ut.ModelName}} as a Database Model
+// This is more for use internally, and probably not what you want in  your controllers
+func (m *{{$ut.ModelName}}DB) GetAsync(ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}, {{$ut.PKAttributes}}) {{$ut.ModelName}}Channel {
+	channel := make({{$ut.ModelName}}Channel)
+
+	go func() {
+		result := {{$ut.ModelName}}Result{}
+		data, err := m.Get(ctx{{ if $ut.DynamicTableName}}, tableName{{ end }}, {{$ut.PKAttributeNames}})
+		result.Data = data
+		result.Err = err
+		channel <- result
+		close(channel)
+	}()
+	return channel
+}
+
+
 // List returns an array of {{$ut.ModelName}}
 func (m *{{$ut.ModelName}}DB) List(ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}) []{{$ut.ModelName}}{
 	defer goa.MeasureSince([]string{"goa","db","{{goify $ut.ModelName false}}", "list"}, time.Now())
@@ -490,6 +532,21 @@ func (m *{{$ut.ModelName}}DB) List(ctx context.Context{{ if $ut.DynamicTableName
 	}
 
 	return objs
+}
+
+// ListAsync returns an array of {{$ut.ModelName}}
+func (m *{{$ut.ModelName}}DB) ListAsync(ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}) {{$ut.ModelName}}ListChannel {
+	channel := make({{$ut.ModelName}}ListChannel)
+
+	go func() {
+		result := {{$ut.ModelName}}ListResult{}
+		data := m.List(ctx{{ if $ut.DynamicTableName}}, tableName{{ end }})
+		result.Data = data
+		channel <- result
+		close(channel)
+		return
+	}()
+	return channel
 }
 
 // Add creates a new record.  /// Maybe shouldn't return the model, it's a pointer.
@@ -509,6 +566,21 @@ func (m *{{$ut.ModelName}}DB) Add(ctx context.Context{{ if $ut.DynamicTableName 
 	return model, err
 }
 
+// AddAsync creates a new record.  /// Maybe shouldn't return the model, it's a pointer.
+func (m *{{$ut.ModelName}}DB) AddAsync(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, model *{{$ut.ModelName}}) {{$ut.ModelName}}Channel {
+	channel := make({{$ut.ModelName}}Channel)
+
+	go func() {
+		result := {{$ut.ModelName}}Result{}
+		data, err := m.Add(ctx{{ if $ut.DynamicTableName }}, tableName {{ end }}, model)
+		result.Data = *data
+		result.Err = err
+		channel <- result
+		close(channel)
+	}()
+	return channel
+}
+
 // Update modifies a single record.
 func (m *{{$ut.ModelName}}DB) Update(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, model *{{$ut.ModelName}}) error {
 	defer goa.MeasureSince([]string{"goa","db","{{goify $ut.ModelName false}}", "update"}, time.Now())
@@ -526,6 +598,20 @@ func (m *{{$ut.ModelName}}DB) Update(ctx context.Context{{ if $ut.DynamicTableNa
 	return err
 }
 
+// UpdateAsync modifies a single record.
+func (m *{{$ut.ModelName}}DB) UpdateAsync(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, model *{{$ut.ModelName}}) {{$ut.ModelName}}Channel {
+	channel := make({{$ut.ModelName}}Channel)
+
+	go func() {
+		result := {{$ut.ModelName}}Result{}
+		err := m.Update(ctx{{ if $ut.DynamicTableName }}, tableName{{ end }}, model)
+		result.Err = err
+		channel <- result
+		close(channel)
+	}()
+	return channel
+}
+
 // Delete removes a single record.
 func (m *{{$ut.ModelName}}DB) Delete(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}})  error {
 	defer goa.MeasureSince([]string{"goa","db","{{goify $ut.ModelName false}}", "delete"}, time.Now())
@@ -541,6 +627,21 @@ func (m *{{$ut.ModelName}}DB) Delete(ctx context.Context{{ if $ut.DynamicTableNa
 	}
 	{{ if $ut.Cached }} go m.cache.Delete(strconv.Itoa(id)) {{ end }}
 	return  nil
+}
+
+// DeleteAsync removes a single record.
+func (m *{{$ut.ModelName}}DB) DeleteAsync(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}}) {{$ut.ModelName}}Channel {
+	channel := make({{$ut.ModelName}}Channel)
+
+	go func() {
+		result := {{$ut.ModelName}}Result{}
+		err := m.Delete(ctx{{ if $ut.DynamicTableName }}, tableName{{ end }}, {{$ut.PKAttributeNames}})
+		result.Err = err
+		channel <- result
+		close(channel)
+		return
+	}()
+	return channel
 }
 
 {{ range $bfn, $bf := $ut.BuiltFrom }}


### PR DESCRIPTION
A *Result and a corresponding *Channel is generated for each
Model type and View variation.

All methods on *DB is updated to use channels to pass results and errors
back to the user.

Thoughts?
## Generated structs

``` go
// This is the User model and describes a User as in any system
type User struct {
    ID        uuid.UUID `sql:"type:uuid" gorm:"primary_key"` // This is the ID PK field
    CreatedAt time.Time
    DeletedAt *time.Time
    Email     string
    UpdatedAt time.Time
}

// UserResult represents a User result passed over a channel
type UserResult struct {
    Data User
    Err  error
}

// UserListResult represents a []User result passed over a channel
type UserListResult struct {
    Data []User
    Err  error
}

// UserChannel used to pass async User results from DB
type UserChannel chan UserResult

// UserListChannel used to pass async []User results from DB
type UserListChannel chan UserListResult

// UserStorage represents the storage interface.
type UserStorage interface {
    DB() interface{}
    List(ctx context.Context) []User
    Get(ctx context.Context, id uuid.UUID) (User, error)
    Add(ctx context.Context, user *User) (*User, error)
    Update(ctx context.Context, user *User) error
    Delete(ctx context.Context, id uuid.UUID) error

    ListAsync(ctx context.Context) UserListChannel
    GetAsync(ctx context.Context, id uuid.UUID) UserChannel
    AddAsync(ctx context.Context, user *User) UserChannel
    UpdateAsync(ctx context.Context, user *User) UserChannel
    DeleteAsync(ctx context.Context, id uuid.UUID) UserChannel
}
```
## Generated impl

``` go
// Get returns a single User as a Database Model
// This is more for use internally, and probably not what you want in  your controllers
func (m *UserDB) Get(ctx context.Context, id uuid.UUID) (User, error) {
    defer goa.MeasureSince([]string{"goa", "db", "user", "get"}, time.Now())

    var native User
    err := m.Db.Table(m.TableName()).Where("id = ?", id).Find(&native).Error
    if err == gorm.ErrRecordNotFound {
        return User{}, nil
    }

    return native, err
}

// GetAsync returns a single User as a Database Model
// This is more for use internally, and probably not what you want in  your controllers
func (m *UserDB) GetAsync(ctx context.Context, id uuid.UUID) UserChannel {
    channel := make(UserChannel)

    go func() {
        result := UserResult{}
        data, err := m.Get(ctx, id)
        result.Data = data
        result.Err = err
        channel <- result
        close(channel)
    }()
    return channel
}
```
## Usage example

``` go
func TestUserGetSync(t *testing.T) {

    db := NewUserDB()

    // sync
    if result := <-db.GetAsync(nil, uuid.NewV4()); result.Err != nil {
        user := result.Data
        // do x y z
    }
}

func TestUserGetASync(t *testing.T) {

    db := NewUserDB()

    // spawn multiple db request
    chan1 := db.GetAsync(nil, uuid.NewV4())
    chan2 := db.UpdateAsync(nil, nil)

    // do a, b, c

    // sync later
    if res1 := <-chan1; res1.Err != nil {
        // do x
    }
    // sync later
    if res2 := <-chan2; res2.Err != nil {
        // do y
    }
}
```
