### PR TITLE
Add DSL for DatabaseFieldName

### DIFF
--- a/dsl/relationalfield.go
+++ b/dsl/relationalfield.go
@@ -11,6 +11,15 @@ import (
 	"github.com/goadesign/gorma"
 )
 
+// DatabaseFieldName allows for customization of the column name
+// by seting the struct tags. This is necessary to create correlate
+// non standard column naming conventions in gorm.
+func DatabaseFieldName(name string) {
+	if f, ok := relationalFieldDefinition(true); ok {
+		f.DatabaseFieldName = name
+	}
+}
+
 // Field is a DSL definition for a field in a Relational Model.
 // Parameter Options:
 //


### PR DESCRIPTION
This will expose the DatabaseFieldName DSL so that one can set the `gorm:"column:column_name"` struct tag. This is particularly handy when dealing with legacy databases that have inconsistent naming conventions.