### PR TITLE
Many to Many association ignoring table name.

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -126,6 +126,7 @@ type RelationalFieldDefinition struct {
 	Parent            *RelationalModelDefinition
 	a                 *design.AttributeDefinition
 	FieldName         string
+	TableName         string
 	Datatype          FieldType
 	SQLTag            string
 	DatabaseFieldName string // gorm:column

--- a/dsl/relationalmodel.go
+++ b/dsl/relationalmodel.go
@@ -297,6 +297,7 @@ func ManyToMany(other, tablename string) {
 	if r, ok := relationalModelDefinition(false); ok {
 		field := gorma.NewRelationalFieldDefinition()
 		field.FieldName = inflect.Pluralize(other)
+		field.TableName = tablename
 		field.Many2Many = other
 		field.Datatype = gorma.Many2Many
 		field.Description = "many to many " + r.ModelName + "/" + strings.Title(other)

--- a/relationalfield.go
+++ b/relationalfield.go
@@ -135,9 +135,7 @@ func tags(f *RelationalFieldDefinition) string {
 		gormtags = append(gormtags, "primary_key")
 	}
 	if f.Many2Many != "" {
-		p := strings.ToLower(f.Parent.ModelName)
-		j := strings.ToLower(f.Many2Many)
-		gormtags = append(gormtags, "many2many:"+p+"_"+j)
+		gormtags = append(gormtags, "many2many:"+f.TableName)
 	}
 
 	var tags []string


### PR DESCRIPTION
When setting up a many to many association, the table name parameter is ignored. I made a quick fix for this issue.