### PR TITLE
Use int64 for gorma.BigInteger

### DIFF
--- a/relationalfield.go
+++ b/relationalfield.go
@@ -87,8 +87,10 @@ func goDatatype(f *RelationalFieldDefinition, includePtr bool) string {
 	switch f.Datatype {
 	case Boolean:
 		return ptr + "bool"
-	case Integer, BigInteger:
+	case Integer:
 		return ptr + "int"
+	case BigInteger:
+		return ptr + "int64"
 	case AutoInteger, AutoBigInteger:
 		return ptr + "int " // sql/gorm tags later
 	case Decimal:

--- a/relationalfield_test.go
+++ b/relationalfield_test.go
@@ -55,6 +55,7 @@ func TestFieldDefinitions(t *testing.T) {
 	}{
 		{"id", gorma.Integer, "description", false, "", "", "", "", "ID\tint  // description\n"},
 		{"id", gorma.UUID, "description", false, "", "", "", "", "ID\tuuid.UUID  // description\n"},
+		{"id", gorma.BigInteger, "description", false, "", "", "", "", "ID\tint64  // description\n"},
 		{"name", gorma.String, "name", true, "", "", "", "", "Name\t*string  // name\n"},
 		{"user", gorma.HasOne, "has one", false, "", "", "User", "", "User\tUser  // has one\n"},
 		{"user_id", gorma.BelongsTo, "belongs to", false, "", "", "", "", "UserID\tint  // belongs to\n"},


### PR DESCRIPTION
[Gorm](https://github.com/jinzhu/gorm) parses go type `int64` to sql type `bigint` so gorma should parses `gorma.BigInteger` to `int64`.