### PR TITLE
Update README to reflect that PK Field is required for Get to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,19 @@ Write a storage definition using DSL from the `dsl` package.  Example:
 				BuildsFrom(func() {
 					Payload("myresource","actionname")  // e.g. "bottle", "create" resource definition
 				})
+
 				RendersTo(Bottle)						// a Media Type definition
 				Description("This is the bottle model")
-				Field("ID", gorma.Integer, func() {    //  redundant
+
+				Field("ID", gorma.Integer, func() {    // Required for CRUD getters to take a PK argument!
 					PrimaryKey()
 					Description("This is the ID PK field")
 				})
+
 				Field("Vintage", gorma.Integer, func() {
 					SQLTag("index")						// Add an index
 				})
+
 				Field("CreatedAt", gorma.Timestamp)
 				Field("UpdatedAt", gorma.Timestamp)			 // Shown for demonstration
 				Field("DeletedAt", gorma.NullableTimestamp)  // These are added by default


### PR DESCRIPTION
The existing README marks the `Field` definition for a primary key as redundant. 

This is misleading due to the fact that the CRUD `Get` method won't generate with an integer argument unless you have this Field declaration for the primary key. Same for the model helper method `OneFoo`.

There has been some chatter on the Slack channel about altering the default behavior. But until then, hopefully altering this documentation example will save some people some pain.