### PR TITLE
Add SQLite3 storagetype to gorma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-- 1.5.3
-- 1.6
+- 1.6.3
+- 1.7.1
 sudo: false
 install:
 - go get -v ./...
@@ -31,4 +31,4 @@ deploy:
   cache-control: max-age=300
   on:
     repo: goadesign/gorma
-    go: '1.5.3'
+    go: '1.6.3'

--- a/init.go
+++ b/init.go
@@ -11,6 +11,8 @@ const (
 	MySQL RelationalStorageType = "mysql"
 	// Postgres is the StorageType for Postgres
 	Postgres RelationalStorageType = "postgres"
+	// SQLite3 is the StorageType for SQLite3 databases
+	SQLite3 RelationalStorageType = "sqlite3"
 	// None is For tests
 	None RelationalStorageType = ""
 	// Boolean is a bool field type

--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -63,6 +63,16 @@ func (f RelationalModelDefinition) Children() []dslengine.Definition {
 	return stores
 }
 
+// PKNames constructs field  strings useful for method parameters.
+func (f *RelationalModelDefinition) PKNames() string {
+	var attr []string
+	for _, pk := range f.PrimaryKeys {
+		attr = append(attr, fmt.Sprintf("%s", codegen.Goify(pk.DatabaseFieldName, false)))
+	}
+	return strings.Join(attr, ",")
+}
+
+// PKWhere returns an array of strings representing the where clause
 // PKAttributes constructs a pair of field + definition strings
 // useful for method parameters.
 func (f *RelationalModelDefinition) PKAttributes() string {

--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -72,7 +72,6 @@ func (f *RelationalModelDefinition) PKNames() string {
 	return strings.Join(attr, ",")
 }
 
-// PKWhere returns an array of strings representing the where clause
 // PKAttributes constructs a pair of field + definition strings
 // useful for method parameters.
 func (f *RelationalModelDefinition) PKAttributes() string {

--- a/writers.go
+++ b/writers.go
@@ -427,7 +427,7 @@ type {{$ut.ModelName}}Storage interface {
 	List(ctx context.Context{{ if $ut.DynamicTableName}}, tableName string{{ end }}) ([]*{{$ut.ModelName}}, error)
 	Get(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}}) (*{{$ut.ModelName}}, error)
 	Add(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}} *{{$ut.ModelName}}) (error)
-	Update(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.LowerName}} *{{$ut.ModelName}}) (error)
+	Update(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}}, update map[string]interface{}) (error)
 	Delete(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{ $ut.PKAttributes}}) (error)
 {{range $rname, $rmt := $ut.RenderTo}}{{/*
 
@@ -516,15 +516,15 @@ func (m *{{$ut.ModelName}}DB) Add(ctx context.Context{{ if $ut.DynamicTableName 
 }
 
 // Update modifies a single record.
-func (m *{{$ut.ModelName}}DB) Update(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, model *{{$ut.ModelName}}) error {
+func (m *{{$ut.ModelName}}DB) Update(ctx context.Context{{ if $ut.DynamicTableName }}, tableName string{{ end }}, {{$ut.PKAttributes}}, update map[string]interface{}) error {
 	defer goa.MeasureSince([]string{"goa","db","{{goify $ut.ModelName false}}", "update"}, time.Now())
 
-	obj, err := m.Get(ctx{{ if $ut.DynamicTableName }}, tableName{{ end }}, {{$ut.PKUpdateFields "model"}})
+	obj, err := m.Get(ctx{{ if $ut.DynamicTableName }}, tableName{{ end }}, {{$ut.PKNames}})
 	if err != nil {
 		goa.LogError(ctx, "error updating {{$ut.ModelName}}", "error", err.Error())
 		return  err
 	}
-	err = m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Model(obj).Updates(model).Error
+	err = m.Db{{ if $ut.DynamicTableName }}.Table(tableName){{ end }}.Model(obj).Updates(update).Error
 	{{ if $ut.Cached }}go func(){
 		m.cache.Set(strconv.Itoa(model.ID), obj, cache.DefaultExpiration)
 	}()


### PR DESCRIPTION
This PR will add the SQLite3 StorageType to gorma.
SQLite is an ideal database to use for development purposes. Supporting SQLite3 in gorma will help with local development of gorma backed API's.

Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>