### PR TITLE
Add SQLite3 storagetype to gorma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-- 1.5.3
-- 1.6
+- 1.6.3
+- 1.7.1
 sudo: false
 install:
 - go get -v ./...
@@ -31,4 +31,4 @@ deploy:
   cache-control: max-age=300
   on:
     repo: goadesign/gorma
-    go: '1.5.3'
+    go: '1.6.3'

--- a/init.go
+++ b/init.go
@@ -11,6 +11,8 @@ const (
 	MySQL RelationalStorageType = "mysql"
 	// Postgres is the StorageType for Postgres
 	Postgres RelationalStorageType = "postgres"
+	// SQLite3 is the StorageType for SQLite3 databases
+	SQLite3 RelationalStorageType = "sqlite3"
 	// None is For tests
 	None RelationalStorageType = ""
 	// Boolean is a bool field type


### PR DESCRIPTION
This PR will add the SQLite3 StorageType to gorma.
SQLite is an ideal database to use for development purposes. Supporting SQLite3 in gorma will help with local development of gorma backed API's.

Signed-off-by: Jeroen Simonetti jeroen@simonetti.nl
