### PR TITLE
add condition generating "column" tag for gorm

### DIFF
--- a/relationalfield.go
+++ b/relationalfield.go
@@ -130,7 +130,9 @@ func tags(f *RelationalFieldDefinition) string {
 	}
 
 	var gormtags []string
-	if f.DatabaseFieldName != "" && f.DatabaseFieldName != f.Underscore() {
+	if f.DatabaseFieldName != "" &&
+		(f.DatabaseFieldName != f.Underscore() ||
+			(f.PrimaryKey && f.Underscore() != "id")) {
 		gormtags = append(gormtags, "column:"+f.DatabaseFieldName)
 	}
 	if f.PrimaryKey {

--- a/relationalfield_test.go
+++ b/relationalfield_test.go
@@ -93,7 +93,7 @@ func TestTags(t *testing.T) {
 		{"ID", "", gorma.Integer, true, "", "", "`gorm:\"primary_key\"`"},
 		{"ID", "test_id", gorma.Integer, true, "", "", "`gorm:\"column:test_id;primary_key\"`"},
 		{"ID", "", gorma.Integer, false, "", "", ""},
-		{"TestID", "test_id", gorma.Integer, true, "", "", "`gorm:\"primary_key\"`"},
+		{"TestID", "test_id", gorma.Integer, true, "", "", "`gorm:\"column:test_id;primary_key\"`"},
 		{"TestID", "", gorma.Integer, false, "many2many", "tests_resultstest", "`gorm:\"many2many:tests_resultstest\"`"},
 	}
 	for _, tt := range tagtests {

--- a/relationalfield_test.go
+++ b/relationalfield_test.go
@@ -78,3 +78,37 @@ func TestFieldDefinitions(t *testing.T) {
 	}
 
 }
+
+func TestTags(t *testing.T) {
+
+	var tagtests = []struct {
+		name         string
+		dbcolumnname string
+		datatype     gorma.FieldType
+		primaryKey   bool
+		many2many    string
+		tableName    string
+		expected     string
+	}{
+		{"ID", "", gorma.Integer, true, "", "", "`gorm:\"primary_key\"`"},
+		{"ID", "test_id", gorma.Integer, true, "", "", "`gorm:\"column:test_id;primary_key\"`"},
+		{"ID", "", gorma.Integer, false, "", "", ""},
+		{"TestID", "test_id", gorma.Integer, true, "", "", "`gorm:\"primary_key\"`"},
+		{"TestID", "", gorma.Integer, false, "many2many", "tests_resultstest", "`gorm:\"many2many:tests_resultstest\"`"},
+	}
+	for _, tt := range tagtests {
+		f := &gorma.RelationalFieldDefinition{}
+		f.FieldName = dsl.SanitizeFieldName(tt.name)
+		f.DatabaseFieldName = tt.dbcolumnname
+		f.Datatype = tt.datatype
+		f.PrimaryKey = tt.primaryKey
+		f.Many2Many = tt.many2many
+		f.TableName = tt.tableName
+		def := f.Tags()
+
+		if def != tt.expected {
+			t.Errorf("expected %s,got %s", tt.expected, def)
+		}
+	}
+
+}


### PR DESCRIPTION
i want to generate 'gorm:"column:xxx"' tag  additionally when databasefield is PrimaryKey and it's name is not just "id".

i'm using gorma with tables that their primary key is not standard naming rule for column name not 'id'  but 'sometable_id', with 'manyToMany' reference to another table.

gorma now generate a tag like "gorm:column:xxx" only on condition below.

```
if f.DatabaseFieldName != "" && f.DatabaseFieldName != f.Underscore()
```

but gorm seems using not only fieldname and also tablename when 'gorm:"column:xxx"' tag is not set.
so, i added some if-conditions to relationalfield.go

