### PR TITLE
Fix Links override for Types with more than one link

### DIFF
--- a/writers.go
+++ b/writers.go
@@ -105,6 +105,11 @@ func fieldAssignmentModelToType(model *RelationalModelDefinition, ut *design.Vie
 	var fieldAssignments []string
 
 	if !strings.Contains(ut.Name, "link") {
+		if len(ut.Parent.Links) > 0 {
+			ifa := fmt.Sprintf("%s.Links = &app.%sLinks{}", utype, codegen.Goify(utype, true))
+			fieldAssignments = append(fieldAssignments, ifa)
+		}
+
 		for ln, lnd := range ut.Parent.Links {
 			ln = codegen.Goify(ln, true)
 			s := inflect.Singularize(ln)
@@ -122,7 +127,7 @@ func fieldAssignmentModelToType(model *RelationalModelDefinition, ut *design.Vie
 			}
 
 			fieldAssignments = append(fieldAssignments, ifb)
-			ifd := fmt.Sprintf("%s.Links = &app.%sLinks{%s: tmp%d}", utype, codegen.Goify(utype, true), codegen.Goify(ln, true), tmp)
+			ifd := fmt.Sprintf("%s.Links.%s = tmp%d", utype, codegen.Goify(ln, true), tmp)
 			fieldAssignments = append(fieldAssignments, ifd)
 			tmp++
 		}


### PR DESCRIPTION
When you have a model where a type has more than one `Link`, the helper generated to convert from the `ModelType` to the `MediaType` doesn't correctly setup the `Links`. It will be easier to show with an example.

Having a `Profile` MediaType with a definition like below:

```go
Attribute("checktype", "application/vnd.checktype+json", "Type of check this profile is for")
        Attribute("asset", "application/vnd.asset+json", "Asset this profile is for")
        Links(func() {
            Link("checktype")
            Link("asset")
        })
        Required("id", "href")
```

```go 
   View("default", func() {
        Attribute("id")
        Attribute("href")
        Attribute("links")
    })
```

The code generated for the helper is something like:

```go
func (m *Profile) ProfileToProfileExtended() *app.ProfileExtended {
profile := &app.ProfileExtended{}
    tmp1 := m.Checktype.ChecktypeToChecktypeLink()
    profile.Links = &app.ProfileLinks{Checktype: tmp1} // First assignment
    tmp2 := m.Asset.AssetToAssetLink()
    profile.Links = &app.ProfileLinks{Asset: tmp2} // Second assignment overwrites the first one

    .....
}
```

As it can be seen, the `profile.Links` structure is overwritten in its second assignment. 

This PR tries to modify the behaviour to something like this:

```go
func (m *Profile) ProfileToProfileExtended() *app.ProfileExtended {
	profile := &app.ProfileExtended{}
	profile.Links = &app.ProfileLinks{} // Initialises the Links structure
	tmp1 := m.Checktype.ChecktypeToChecktypeLink()
	profile.Links.Checktype = tmp1 // Assigns the first property
	tmp2 := m.Asset.AssetToAssetLink()
	profile.Links.Asset = tmp2 // Assigns the second property without overwriting the previous one
	
        .....
}
```

Seems that the build was failing in `master` before the PR, so it's still failing with it.

Any feedback is more than welcome. Thanks!