### PR TITLE
Change the Datatype for NumberKind to BigDecimal

### DIFF
--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -253,7 +253,7 @@ func (f *RelationalModelDefinition) PopulateFromModeledType() {
 				case design.IntegerKind:
 					rf.Datatype = Integer
 				case design.NumberKind:
-					rf.Datatype = Decimal
+					rf.Datatype = BigDecimal
 				case design.StringKind:
 					rf.Datatype = String
 				case design.DateTimeKind:
@@ -285,7 +285,7 @@ func (f *RelationalModelDefinition) PopulateFromModeledType() {
 			case design.IntegerKind:
 				rf.Datatype = Integer
 			case design.NumberKind:
-				rf.Datatype = Decimal
+				rf.Datatype = BigDecimal
 			case design.StringKind:
 				rf.Datatype = String
 			case design.DateTimeKind:


### PR DESCRIPTION
The `Number` go native type in goa is float64, so it should be a float64
in the Model.

From gorma `relationalmodel.go`:
```go
// PopulateFromModeledType creates fields for the model
// based on the goa UserTypeDefinition it models, which is
// set using BuildsFrom().
// This happens before fields are processed, so it's
// ok to just assign without testing.
func (f *RelationalModelDefinition) PopulateFromModeledType() {
	...
				case design.NumberKind:
					rf.Datatype = Decimal
				...
				
			case design.NumberKind:
				rf.Datatype = Decimal
			...
```

From gorma `relationalfield.go`:
```go
func goDatatype(f *RelationalFieldDefinition, includePtr bool) string {
	...
	case Decimal:
		return ptr + "float32"
	case BigDecimal:
		return ptr + "float64"
...
```

From goa `goagen/codegen/types.go`:
```go
// GoNativeType returns the Go built-in type from which instances of t can be initialized.
func GoNativeType(t design.DataType) string {
	...
		case design.NumberKind:
			return "float64"
      ...
```

Compiling without the change:
```
models/result.go:180: cannot use payload.Score (type *float64) as type *float32 in assignment
models/result.go:203: cannot use payload.Score (type *float64) as type *float32 in assignment
models/result_helper.go:50: cannot use m.Score (type *float32) as type *float64 in assignment
```

Don't know whether that change has more implications or not. At least in our case changing that did the trick.