### PR TITLE
Fix Makefile to generate docs correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,10 @@ DEPEND=\
 all: depend lint test
 
 docs:
-	@git clone https://github.com/goadesign/goa.design
-	@rm -rf goa.design/content/reference goa.design/public
-	@mdc --exclude goa.design --exclude example github.com/goadesign/gorma goa.design/content/reference
-	@cd goa.design && hugo
+	@cd /tmp && git clone https://github.com/goadesign/goa.design && cd goa.design && rm -rf content/reference public && make docs && hugo
 	@rm -rf public
-	@mv goa.design/public public
-	@rm -rf goa.design
+	@mv /tmp/goa.design/public public
+	@rm -rf /tmp/goa.design
 
 depend:
 	@go get -u $(DEPEND)


### PR DESCRIPTION
Build of gorma is failing due to the `make docs` command. One partial fix might be changing the current:
```
@mdc --exclude goa.design --exclude example github.com/goadesign/gorma goa.design/content/reference
```

by a comma separated `exclude` flag value:
```
@mdc --exclude goa.design,example github.com/goadesign/gorma goa.design/content/reference
```

But hugo is still failing with:
`ERROR 2017/03/02 18:44:43 No page found with path or logical name "reference/goa/design/apidsl.md".`

So the `Makefile` has been changed a bit to generate the content of public outside of the build directory, and then copying it back there. The `mdc` call has been removed as it's already called in the `goa.design` `make docs` call:

```
docs:
    @mdc --exclude public         github.com/goadesign/goa   content/reference
    @mdc --exclude public,example github.com/goadesign/gorma content/reference
```