### PR TITLE
Fix Incorrect column name is set by Field method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
 - export PATH=${PATH}:${HOME}/bin
 - make
-- make docs
+- if [ "$TRAVIS_GO_VERSION" = "1.7.1" ]; then make docs; fi
 notifications:
   slack:
     secure: bMYXaoSEGoNdqR0t1VnMAv/4V9PSOhEWyekdJM7p9WmKjJi2yKy0k77uRmwf+5Mrz5GLs3CkZnDha/8cSFld3KEN9SC6QYmIBF/1Pd/5mKHFQOI81i7sTlhrdMv897+6sofEtbBNq1jffhVGVttbMrMWwCTNZu0NrCGBVsDmb44=

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ DEPEND=\
 	github.com/goadesign/goa.design/tools/godoc2md \
 	github.com/golang/lint/golint \
 	github.com/onsi/ginkgo \
-	github.com/spf13/hugo \
 	github.com/onsi/ginkgo/ginkgo \
 	github.com/onsi/gomega \
 	golang.org/x/tools/cmd/goimports \
@@ -26,6 +25,7 @@ DEPEND=\
 all: depend lint test
 
 docs:
+	@go get -v github.com/spf13/hugo
 	@cd /tmp && git clone https://github.com/goadesign/goa.design && cd goa.design && rm -rf content/reference public && make docs && hugo
 	@rm -rf public
 	@mv /tmp/goa.design/public public

--- a/dsl/relationalfield_test.go
+++ b/dsl/relationalfield_test.go
@@ -38,6 +38,11 @@ var _ = Describe("RelationalField", func() {
 			//gdsl.BuildsFrom(RandomPayload)
 			gdsl.Field(name, ft, dsl)
 			gdsl.Field("id", gorma.Integer, dsl) // use lowercase "id" to test sanitizer
+			gdsl.Field("API", gorma.String)
+			gdsl.Field("url", gorma.String)
+			gdsl.Field("APIType", gorma.String)
+			gdsl.Field("xml_type", gorma.String)
+			gdsl.Field("", gorma.String)
 			gdsl.Field("MiddleName", gorma.String)
 			gdsl.Field("CreatedAt", gorma.Timestamp)
 			gdsl.Field("UpdatedAt", gorma.Timestamp)
@@ -117,6 +122,12 @@ var _ = Describe("RelationalField", func() {
 				rs := sg.RelationalStores[storename]
 				rm := rs.RelationalModels[modelname]
 				Ω(rm.RelationalFields["ID"].FieldName).Should(Equal("ID"))
+				Ω(rm.RelationalFields["API"].FieldName).Should(Equal("API"))
+				Ω(rm.RelationalFields["URL"].FieldName).Should(Equal("URL"))
+				Ω(rm.RelationalFields["APIType"].FieldName).Should(Equal("APIType"))
+				Ω(rm.RelationalFields["XMLType"].FieldName).Should(Equal("XMLType"))
+				Ω(rm.RelationalFields[""].FieldName).Should(Equal(""))
+				Ω(rm.RelationalFields["ID"].FieldName).Should(Equal("ID"))
 			})
 			It("sets the field type", func() {
 				sg := gorma.GormaDesign
@@ -151,7 +162,7 @@ var _ = Describe("RelationalField", func() {
 				rs := sg.RelationalStores[storename]
 				rm := rs.RelationalModels[modelname]
 				length := len(rm.RelationalFields)
-				Ω(length).Should(Equal(6))
+				Ω(length).Should(Equal(11))
 			})
 		})
 


### PR DESCRIPTION
for https://github.com/goadesign/gorma/issues/142

I thought that SanitizeDBFieldName was a method to be executed when the field name was id, and switched to a flow to execute after checking the original name before execution.

There are points I wondered.
We recognize that the field names in the database allow only snake cases, but are there any mistakes?

https://github.com/goadesign/gorma-cellar/blob/master/design/models.go
https://github.com/goadesign/gorma/blob/master/README.md
Sample seems to assume that a field name is attached in a snake case, but in README, I felt doubtful because it was named in the upper camel case.