### PR TITLE
fix:  pluralize in mistaken word

### DIFF
--- a/dsl/relationalmodel.go
+++ b/dsl/relationalmodel.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/gorma"
+	"github.com/jinzhu/inflection"
 )
 
 // Model is the DSL that represents a Relational Model.
@@ -244,7 +245,7 @@ func HasMany(name, child string) {
 		field := gorma.NewRelationalFieldDefinition()
 		field.FieldName = codegen.Goify(name, true)
 		field.HasMany = child
-		field.Description = "has many " + inflect.Pluralize(child)
+		field.Description = "has many " + inflection.Plural(child)
 		field.Datatype = gorma.HasMany
 		field.Parent = r
 		r.RelationalFields[field.FieldName] = field
@@ -296,7 +297,7 @@ func HasMany(name, child string) {
 func ManyToMany(other, tablename string) {
 	if r, ok := relationalModelDefinition(false); ok {
 		field := gorma.NewRelationalFieldDefinition()
-		field.FieldName = inflect.Pluralize(other)
+		field.FieldName = inflection.Plural(other)
 		field.TableName = tablename
 		field.Many2Many = other
 		field.Datatype = gorma.Many2Many

--- a/manytomany.go
+++ b/manytomany.go
@@ -3,19 +3,19 @@ package gorma
 import (
 	"strings"
 
-	"bitbucket.org/pkg/inflect"
+	"github.com/jinzhu/inflection"
 )
 
 // LeftNamePlural returns the pluralized version of
 // the "owner" of the m2m relationship.
 func (m *ManyToManyDefinition) LeftNamePlural() string {
-	return inflect.Pluralize(m.Left.ModelName)
+	return inflection.Plural(m.Left.ModelName)
 }
 
 // RightNamePlural returns the pluralized version
 // of the "child" of the m2m relationship.
 func (m *ManyToManyDefinition) RightNamePlural() string {
-	return inflect.Pluralize(m.Right.ModelName)
+	return inflection.Plural(m.Right.ModelName)
 }
 
 // LeftName returns the name of the "owner" of the

--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
+	"github.com/jinzhu/inflection"
 )
 
 // NewRelationalModelDefinition returns an initialized
@@ -51,7 +52,7 @@ func (f *RelationalModelDefinition) DSL() func() {
 
 // TableName returns the TableName of the struct.
 func (f RelationalModelDefinition) TableName() string {
-	return inflect.Underscore(inflect.Pluralize(f.ModelName))
+	return inflect.Underscore(inflection.Plural(f.ModelName))
 }
 
 // Children returns a slice of this objects children.

--- a/relationalmodel_test.go
+++ b/relationalmodel_test.go
@@ -205,3 +205,19 @@ func TestPKUpdateFieldsMultiple(t *testing.T) {
 	}
 
 }
+
+func TestTableName(t *testing.T) {
+	sg := &gorma.RelationalModelDefinition{}
+	sg.ModelName = "status"
+	if sg.TableName() != "statuses" {
+		t.Errorf("Expected %s, got %s", "statuses", sg.TableName())
+	}
+	sg.ModelName = "study"
+	if sg.TableName() != "studies" {
+		t.Errorf("Expected %s, got %s", "studies", sg.TableName())
+	}
+	sg.ModelName = "user"
+	if sg.TableName() != "users" {
+		t.Errorf("Expected %s, got %s", "users", sg.TableName())
+	}
+}

--- a/writers.go
+++ b/writers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
+	"github.com/jinzhu/inflection"
 	"github.com/kr/pretty"
 )
 
@@ -340,7 +341,7 @@ func (w *UserHelperWriter) Execute(data *UserTypeTemplateData) error {
 	fm["viewFieldNames"] = viewFieldNames
 	fm["goDatatype"] = goDatatype
 	fm["goDatatypeByModel"] = goDatatypeByModel
-	fm["plural"] = inflect.Pluralize
+	fm["plural"] = inflection.Plural
 	fm["gtt"] = codegen.GoTypeTransform
 	fm["gttn"] = codegen.GoTypeTransformName
 	fm["gptn"] = codegen.GoTypeName
@@ -369,7 +370,7 @@ func (w *UserTypesWriter) Execute(data *UserTypeTemplateData) error {
 	fm["viewFieldNames"] = viewFieldNames
 	fm["goDatatype"] = goDatatype
 	fm["goDatatypeByModel"] = goDatatypeByModel
-	fm["plural"] = inflect.Pluralize
+	fm["plural"] = inflection.Plural
 	fm["gtt"] = codegen.GoTypeTransform
 	fm["gttn"] = codegen.GoTypeTransformName
 	return w.ExecuteTemplate("types", userTypeT, fm, data)


### PR DESCRIPTION
```go
bitbucket.org/pkg/inflect
inflect.Pluralize("status") -> status (x)

github.com/jinzhu/inflection 
inflection.Plural("status") -> statuses(◯)
```

If you use `bitbucket.org/pkg/inflect Pluralize`, the result that is different from the result you want is returned as described above.
The reason is simply because the method of the specification is just judging with the trailing letters.
As a countermeasure, you receive correct results by using `github.com/jinzhu/inflection inflection.Plural`.

Also, if you have the necessary test cases suggestions please.