### PR TITLE
Fix to follow updated goa

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -131,7 +131,7 @@ func (g *Generator) generateUserTypes(outdir string, api *design.APIDefinition) 
 				fmt.Println(err)
 				return err
 			}
-			err = utWr.FormatCode()
+			err = utWr.Format()
 			if err != nil {
 				fmt.Println(err)
 			}
@@ -194,7 +194,7 @@ func (g *Generator) generateUserHelpers(outdir string, api *design.APIDefinition
 				fmt.Println(err)
 				return err
 			}
-			err = utWr.FormatCode()
+			err = utWr.Format()
 			if err != nil {
 				fmt.Println(err)
 			}


### PR DESCRIPTION
Thank you for the great project :)

`UserTypesWriter` don't have `FormatCode()`, because goa has been updated.
( https://github.com/goadesign/goa/commit/3937a9859b22fe08bd22d643b8d6f287e57af28a#diff-2daa2cea078146ad7ae47d5346769296L250 )

I made a fix for this issue.